### PR TITLE
fix: obey host OS window events, allow user to quit application cleanly

### DIFF
--- a/arcademachine.h
+++ b/arcademachine.h
@@ -79,7 +79,7 @@ class ArcadeMachine
         */
         void main_menu()
         {
-            while (1)
+            while (! quit_requested())
             {
                 process_events();
                 clear_screen();


### PR DESCRIPTION
This PR ensures that if the user attempts to close the application from an external context (aka ALT+F4, Command+Q) the application will close cleanly and immediately.