### PR TITLE
Feature/add win32 macros

### DIFF
--- a/arcademachine.h
+++ b/arcademachine.h
@@ -285,14 +285,20 @@ class ArcadeMachine
                 if (abs(alpha - 0.0) < 1e-9)
                 {
                     play_sound_effect(sound2);
+
+#ifdef _WIN32
                     Sleep(2000);
                     /*  After this has happened, the alpha value will continue into the negatives
                         The colour function continues to accept negative alpha values, 
                         effectively creating a fade out animation for the remainder of the while loop
                     */
+#endif
                 }
                 refresh_screen(60);
+
+#ifdef _WIN32
                 Sleep(50);
+#endif
             }
         }
 

--- a/gridlayout.h
+++ b/gridlayout.h
@@ -14,7 +14,7 @@ class cell
 public:
     item cellType = EMPTY;
     bitmap bmp = NULL;
-    sprite sprite = NULL;
+    sprite spr = NULL;
     Button *button;
     int span = 1;
     bool centre = true;
@@ -213,10 +213,10 @@ public:
                             write("ScaleToFit: Feature not currently available with use of sprites.\n");
                         if (_grid[index].centre)
                         {
-                            x = x + (((xOffset * _grid[index].span) - sprite_width(_grid[index].sprite)) / 2);
-                            y = y + ((yOffset - sprite_height(_grid[index].sprite)) / 2);
+                            x = x + (((xOffset * _grid[index].span) - sprite_width(_grid[index].spr)) / 2);
+                            y = y + ((yOffset - sprite_height(_grid[index].spr)) / 2);
                         }
-                        draw_sprite(_grid[index].sprite, x, y);
+                        draw_sprite(_grid[index].spr, x, y);
                         break;
                     case BTN:
                         if (_scaleToFit)
@@ -325,7 +325,7 @@ public:
         // Selected row is out of bounds
         // Update the cell
         _grid[cellNum].cellType = BMP;
-        _grid[cellNum].sprite = NULL;
+        _grid[cellNum].spr = NULL;
         _grid[cellNum].bmp = bmp;
         _grid[cellNum].button = NULL;
         _grid[cellNum].span = span;
@@ -349,7 +349,7 @@ public:
         // Selected row is out of bounds
         // Update the cell
         _grid[cellNum].cellType = SPT;
-        _grid[cellNum].sprite = sprite;
+        _grid[cellNum].spr = sprite;
         _grid[cellNum].bmp = NULL;
         _grid[cellNum].button = NULL;
         _grid[cellNum].span = span;
@@ -373,7 +373,7 @@ public:
         // Selected row is out of bounds
         // Update the cell
         _grid[cellNum].cellType = BTN;
-        _grid[cellNum].sprite = NULL;
+        _grid[cellNum].spr = NULL;
         _grid[cellNum].bmp = NULL;
         _grid[cellNum].button = button;
         _grid[cellNum].span = span;
@@ -394,7 +394,7 @@ public:
         {
             // Update bitmap
             _grid[i].cellType = BMP;
-            _grid[i].sprite = NULL;
+            _grid[i].spr = NULL;
             _grid[i].bmp = bmp;
             _grid[i].centre = centre;
         }
@@ -414,7 +414,7 @@ public:
         {
             // Update bitmap
             _grid[i].cellType = SPT;
-            _grid[i].sprite = sprite;
+            _grid[i].spr = sprite;
             _grid[i].bmp = NULL;
             _grid[i].centre = centre;
         }
@@ -461,7 +461,7 @@ public:
         {
             // Reset cell to default
             _grid[i].cellType = EMPTY;
-            _grid[i].sprite = NULL;
+            _grid[i].spr = NULL;
             _grid[i].bmp = NULL;
             _grid[i].span = 1;
             _grid[i].centre = true;
@@ -521,7 +521,7 @@ public:
         int cellNum = FindCell(row, col);
         // Clear cell
         _grid[cellNum].cellType = EMPTY;
-        _grid[cellNum].sprite = NULL;
+        _grid[cellNum].spr = NULL;
         _grid[cellNum].bmp = NULL;
         _grid[cellNum].button = NULL;
         _grid[cellNum].span = 1;

--- a/includes.h
+++ b/includes.h
@@ -15,7 +15,10 @@
 #include <string>
 #include <chrono>
 //#include <json/json.h>
+
+#ifdef _WIN32
 #include <Windows.h>
+#endif
 
 // Custom classes
 #include "buttons.h"

--- a/menu.h
+++ b/menu.h
@@ -7,6 +7,8 @@ private:
     string background = "games_dashboard";
     // Vector to store the config data of each game
     vector<ConfigData> _games;
+
+#ifdef _WIN32
     // Contains info about newly created process and thread
     PROCESS_INFORMATION processInfo;
     // Unsigned int to store exit info
@@ -17,6 +19,8 @@ private:
     LPSTR _gameExe;
     // Holds the game directory of selected game
     LPCSTR _gameDir;
+#endif
+
     // Used to find x centre of screen
     double _center_x = 960;
     // Used to fine y centre of screen
@@ -43,8 +47,12 @@ private:
     Selector _selector_games_menu;
     // Passes into Selector optional parameter.
     bool game_menu = true;
+
+#ifdef _WIN32
     // Handle for game window.
     HWND handle;
+#endif
+
     // Determines when game has started.
     bool _game_started = false;
     // Starting position of button x.
@@ -72,7 +80,10 @@ public:
     Menu(vector<ConfigData> configs)
     {
         this->_games = configs;
+
+#ifdef _WIN32
         handle = FindWindowA(NULL, "arcade-machine");
+#endif
     }
     ~Menu(){}
 
@@ -186,7 +197,9 @@ public:
         this->button = this->_selector_games_menu.check_key_input(this->button, game_menu);
         this->_action = this->_selector_games_menu.check_for_selection(this->button, game_menu);
 
+#ifdef _WIN32
         check_game_exit();
+#endif
 
         if (this->button)
         {
@@ -198,12 +211,14 @@ public:
             {
                 if (_overlayActive)
                 {
+#ifdef _WIN32
                     // Get game path
                     _gamePath = (this->button->config.folder() + "/" + this->button->config.exe()).c_str();
                     // Get executable name
                     _gameExe = strdup(this->button->config.exe().c_str());
                     // Get game directory
                     _gameDir = this->button->config.folder().c_str();
+#endif
 
                     // Set the center of the game
                     this->_x = _center_x;
@@ -224,8 +239,11 @@ public:
                     fade_music_out(1000);
                     // fade back in
                     fade(1, 0, 0.1);
+
+#ifdef _WIN32
                     // Call method to open game executable
                     start_game(_gamePath, _gameExe, _gameDir);
+#endif
 
                     return;
                 }
@@ -376,6 +394,7 @@ public:
         draw_text("Repository: " + config.repo(), COLOR_WHITE, "font_text", y_offset, x_offset, y_start + (5 * y_offset));
     }
 
+#ifdef _WIN32
     /**
      * @brief  Find the game window and bring it to focus, if it exists
      * 
@@ -410,8 +429,11 @@ public:
             write_line("Unable to find gameWindow Handle");
             return false;
         }
+        return true;
     }
+#endif
 
+#ifdef _WIN32
     /**
      * @brief Starts up the selected game by starting a new process.
      * 
@@ -458,7 +480,9 @@ public:
             this->_in_game = true;
         }
     }
+#endif
    
+#ifdef _WIN32
    /**
      * @brief Waits for game to exit.
      * 
@@ -477,6 +501,7 @@ public:
             }
         }
     }
+#endif
 
     /** 
      * @brief Fade back to games menu
@@ -515,7 +540,10 @@ public:
             // Update the alpha value.
             alphaStart += alphaStep;
             refresh_screen(60);
+
+#ifdef _WIN32
             Sleep(50);
+#endif
         }
     }
 };


### PR DESCRIPTION
I've just added a bunch of preprocessor macros that check the system, and skip over some code if you are not on Windows. This just makes it easier to compile with Linux/MacOS.

This is a **temporary** measure that completely ignores the Winapi functions if you aren't on Windows. Eventually when we are able to add proper cross-platform support these will be refactored to be much neater.

If @studioant / @Delcari is able to confirm this still compiles and works the same on Windows then this should be able to merge no problems.