### PR TITLE
Refactor: Use SplashKit's built-in delay() over Windows-specific Sleep()

### DIFF
--- a/ArcadeMachine.h
+++ b/ArcadeMachine.h
@@ -282,13 +282,15 @@ class ArcadeMachine
                 // Decrement i and alpha 
                 i--; alpha = alpha - 0.05;
                 // If alpha is == 0, hold image for 1.5 seconds
-
                 if (abs(alpha - 0.0) < 1e-9)
                 {
                     play_sound_effect(sound2);
                     delay(2000);
+                    /*  After this has happened, the alpha value will continue into the negatives
+                        The colour function continues to accept negative alpha values, 
+                        effectively creating a fade out animation for the remainder of the while loop
+                    */
                 }
-
                 refresh_screen(60);
                 delay(50);
             }

--- a/ArcadeMachine.h
+++ b/ArcadeMachine.h
@@ -282,23 +282,15 @@ class ArcadeMachine
                 // Decrement i and alpha 
                 i--; alpha = alpha - 0.05;
                 // If alpha is == 0, hold image for 1.5 seconds
+
                 if (abs(alpha - 0.0) < 1e-9)
                 {
                     play_sound_effect(sound2);
-
-#ifdef _WIN32
-                    Sleep(2000);
-                    /*  After this has happened, the alpha value will continue into the negatives
-                        The colour function continues to accept negative alpha values, 
-                        effectively creating a fade out animation for the remainder of the while loop
-                    */
-#endif
+                    delay(2000);
                 }
-                refresh_screen(60);
 
-#ifdef _WIN32
-                Sleep(50);
-#endif
+                refresh_screen(60);
+                delay(50);
             }
         }
 

--- a/menu.h
+++ b/menu.h
@@ -414,7 +414,7 @@ public:
         do {
             gameWindowHandle = FindWindowEx(NULL,NULL,NULL, gameWindow);
             timeElapsed = chrono::duration_cast<chrono::milliseconds>(chrono::steady_clock::now() - startTime).count();
-            Sleep(250);
+            delay(250);
         }
         while (gameWindowHandle == NULL && timeElapsed <= timeout);
 
@@ -541,9 +541,7 @@ public:
             alphaStart += alphaStep;
             refresh_screen(60);
 
-#ifdef _WIN32
-            Sleep(50);
-#endif
+            delay(50);
         }
     }
 };


### PR DESCRIPTION
SplashKit core already has a multi-platform solution to `Sleep()` from `windows.h` by linking to `SDL2` [1]

This PR refactors Windows-specific `Sleep` calls with SplashKit `delay` calls to ensure animations are consistent across platforms.

[1] https://github.com/splashkit/splashkit-core/blob/9d52e752d1ea9d1b80a618794611661aa54afd1e/coresdk/src/backend/utils_driver.cpp#L19