### PR TITLE
Fix: Compilation Issues

### DIFF
--- a/ArcadeMachine.h
+++ b/ArcadeMachine.h
@@ -11,12 +11,12 @@
 #include "Button.h"
 #include "ButtonList.h"
 #include "ConfigData.h"
-#include "gridlayout.h"
+#include "GridLayout.h"
 #include "Helper.h"
-#include "menu.h"
-#include "option.h"
-#include "splashscreen.h"
-#include "selector.h"
+#include "Menu.h"
+#include "Option.h"
+#include "Splashscreen.h"
+#include "Selector.h"
 #include "splashkit.h"
 #include <string>
 #include <vector>

--- a/ConfigData.h
+++ b/ConfigData.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <regex>
 #include <fstream>
+#include <cstring>
 
 /**
  * @brief Parses the configuration data from config.txt files to a data object

--- a/Helper.h
+++ b/Helper.h
@@ -2,6 +2,7 @@
 #define ARCADE_MACHINE_HELPER_H
 
 #include <experimental/filesystem>
+#include <cstring>
 
 namespace fs = std::experimental::filesystem;
 


### PR DESCRIPTION
# Quick Fix
Compilation issues were introduced with PR #43 .

**NOTE**: I overlooked the issues :eyeglasses: I'm assuming **new** capitalized files were generated in addition unknowingly when changing branches to test. Therefore compilation issues weren't identified.
### EG. 
File names changed: gridlayout.h -> GridLayout.h 
but both files still existed.

Where ArcadeMachine.h includes the gridlayout class as 'gridlayout.h'
