### PR TITLE
Refactor/remove executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode/
 logs/
 **/*.log
+**/*.exe
+**/*.out*


### PR DESCRIPTION
This PR removes the `test.exe` binary and (hopefully) configures git to ignore future binary files.