### PR TITLE
docs: add instructions for installing make on mingw32

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # arcade-machine
 An application to showcase and execute Splashkit games  
 
-## Install
+## Pre-requisites (all operating systems)
+
 + Install the [SplashKit](https://splashkit.io) SDK using the [guide](https://splashkit.io/articles/installation/)
+
+## Pre-requisites (mingw32 / Windows)
+
++ Install `make` using `pacman -S make`
 
 ## Building arcade machine (using the Makefile)
 Compiling Arcade Machine using the Makefile allows incremental building of changed objects.


### PR DESCRIPTION
Adds pre-req instructions to `README.md` for using `make` on `mingw32` on Windows.