### PR TITLE
fix: ensure m_colsArray always has a real address or nullptr

### DIFF
--- a/src/GridLayout.cpp
+++ b/src/GridLayout.cpp
@@ -14,6 +14,7 @@ GridLayout::GridLayout(int rows, int cols, bool scaleToFit)
     _scaleToFit = scaleToFit;
     _rows = rows;
     _cols = cols;
+    m_colsArray = nullptr;
 
     // Calculate number of cells
     _cells = _rows * _cols;


### PR DESCRIPTION
The destructor on `GridLayout` always frees the memory for `m_colsArray` - but there is an overloaded constructor where `m_colsArray` isn't assigned to anything - meaning if the class is created with this constructor, memory at some random address stored in `m_colsArray` will be "freed".

This was resulting in errors like

```
GridLayout: clearing memory...
ArcadeMachine(15503,0x205438600) malloc: *** error for object 0x83f800000: pointer being freed was not allocated
ArcadeMachine(15503,0x205438600) malloc: *** set a breakpoint in malloc_error_break to debug
zsh: abort      ./ArcadeMachine
```

This PR fixes the issue by ensuring `m_colsArray` is set to `nullptr` when it isn't being used (which can safely be deleted).