### PR TITLE
feature/alternative-os-exe

### DIFF
--- a/include/ConfigData.h
+++ b/include/ConfigData.h
@@ -36,8 +36,14 @@ private:
     /// Th author/creator of this game
     std::string m_author;
 
-    /// The path to the executable of this game
-    std::string m_exe;
+    /// The path to the Windows executable of this game
+    std::string m_win_exe;
+
+    /// The path to the Linux binaries of this game
+    std::string m_lin_exe;
+
+    /// The path to the MacOS binaries of this game
+    std::string m_mac_exe;
 
     /// The folder this game is inside
     std::string m_folder;
@@ -53,7 +59,7 @@ public:
     auto setId(int &i) { m_id = i; }
     auto setFolder(std::string &dir) { m_folder = dir; }
     // Getters:
-    auto id()            const -> const int&    { return m_id;            }
+    auto id()            const -> const int&         { return m_id;            }
     auto repo()          const -> const std::string& { return m_repo;          }
     auto language()      const -> const std::string& { return m_language;      }
     auto image()         const -> const std::string& { return m_image;         }
@@ -61,7 +67,9 @@ public:
     auto genre()         const -> const std::string& { return m_genre;         }
     auto rating()        const -> const std::string& { return m_rating;        }
     auto author()        const -> const std::string& { return m_author;        }
-    auto exe()           const -> const std::string& { return m_exe;           }
+    auto win_exe()       const -> const std::string& { return m_win_exe;       }
+    auto lin_exe()       const -> const std::string& { return m_lin_exe;       }
+    auto mac_exe()       const -> const std::string& { return m_mac_exe;       }
     auto folder()        const -> const std::string& { return m_folder;        }
     auto description()   const -> const std::string& { return m_description;   }
 

--- a/src/ConfigData.cpp
+++ b/src/ConfigData.cpp
@@ -76,14 +76,16 @@ void ConfigData::collectConfigData(std::vector<std::string> configs)
 
             if(std::regex_search(s.begin(), s.end(), sm, std::regex("(.*)=(.*)")))
             {
-                if      (sm[1] == "title")       this->m_title = sm[2]; 
+                     if (sm[1] == "title")       this->m_title = sm[2]; 
                 else if (sm[1] == "author")      this->m_author = sm[2];
                 else if (sm[1] == "genre")       this->m_genre = sm[2];
                 else if (sm[1] == "description") this->m_description = sm[2];
                 else if (sm[1] == "rating")      this->m_rating = sm[2];
                 else if (sm[1] == "language")    this->m_language = sm[2];
                 else if (sm[1] == "image")       this->m_image = sm[2];
-                else if (sm[1] == "executable")  this->m_exe = sm[2];
+                else if (sm[1] == "win-exe")     this->m_win_exe = sm[2];
+                else if (sm[1] == "linux-bin")   this->m_lin_exe = sm[2];
+                else if (sm[1] == "macos-bin")   this->m_mac_exe = sm[2];
                 else if (sm[1] == "repository")  this->m_repo = sm[2];
             }
         }
@@ -116,7 +118,9 @@ void ConfigData::collectJsonData(json json_configs)
     this->m_genre    = json_read_string(json_configs, "genre");
     this->m_rating   = json_read_string(json_configs, "rating");
     this->m_author   = json_read_string(json_configs, "author");
-    this->m_exe      = json_read_string(json_configs, "exe");
+    this->m_win_exe  = json_read_string(json_configs, "win-exe");
+    this->m_lin_exe  = json_read_string(json_configs, "lin-exe");
+    this->m_mac_exe  = json_read_string(json_configs, "mac-exe");
 }
 
 /**
@@ -196,7 +200,9 @@ void ConfigData::printConfigData()
     write_line("Repo = " + repo());
     write_line("Language = " + language());
     write_line("Image = " + image());
-    write_line("Exe = " + exe());
+    write_line("Windows Exe = " + win_exe());
+    write_line("Linux Bin = " + lin_exe());
+    write_line("MacOS Bin = " + mac_exe());
     write_line("Folder = " + folder());
     write_line("========================");
 }


### PR DESCRIPTION
## Expand ConfigData class to handle additional config.txt parameters   

The ConfigData class has been expanded to collect `win-exe`, `linux-bin` and `macos-bin` parameters found in config.txt
This allows for compilation in all three OS variants, with any one of which accessible if necessary.

This is one half of the change required to complete this task.
