### PR TITLE
refactor: default to use gcc to prevent clang requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INCDIRS = -Iinclude
-CXX = skm clang++ $(INCDIRS)
+CXX = skm g++ $(INCDIRS)
 src = $(wildcard src/*.cpp)
 obj = $(src:.cpp=.o)
 


### PR DESCRIPTION
This PR ensures the Makefile defaults to use `gcc`. As previously discussed, Raspbian comes bundled with `gcc` - so defaulting to this removes the installation dependency of `clang` on Raspberry Pi.