### PR TITLE
fix/menu-execution

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -155,9 +155,9 @@ void Menu::carouselHandler()
             {
 #ifdef _WIN32
                 // Get game path
-                m_gamePath = (this->m_button->config.folder() + "/" + this->m_button->config.exe()).c_str();
+                m_gamePath = (this->m_button->config.folder() + "/" + this->m_button->config.win_exe()).c_str();
                 // Get executable name
-                m_gameExe = strdup(this->m_button->config.exe().c_str());
+                m_gameExe = strdup(this->m_button->config.win_exe().c_str());
                 // Get game directory
                 m_gameDir = this->m_button->config.folder().c_str();
 #endif


### PR DESCRIPTION
## Bug Fixes

This PR contains two bug fixes

1. ### ConfigData must now access win_exe() getter
PR #63 introduced new property names for the executables, as such the getter names were changed.
Menu.cpp still used the old naming convention to execute games, this is a fix for that.

2. ### Games dir cannot be present in root
The games directory can NOT be present in the root when the machine attempts to clone the repo. 
Git will complain of divergent branches which is solved by purging the games directory.
This PR permanently removes the games dir from root. 