### PR TITLE
add arcade machine player 1 & 2 button mappings

### DIFF
--- a/src/Selector.cpp
+++ b/src/Selector.cpp
@@ -27,8 +27,9 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
         // Check to ensure menu isn't currently sliding.
         if (! m_isSlidingLeft && ! m_isSlidingRight)
         {
-            // Slide left.
-            if (key_typed(LEFT_KEY) && !key_typed(RIGHT_KEY))
+           // Slide left.
+            if ( (key_typed(LEFT_KEY) && !key_typed(RIGHT_KEY)) || 
+                 (key_typed(A_KEY) && !key_typed(D_KEY)) )
             {
                 m_isSlidingLeft = true;
                 // Previous button becomes current button.
@@ -37,7 +38,8 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
                 highlightButton(buttonNode, "prev");
             }
             // Slide right.
-            if (key_typed(RIGHT_KEY) && !key_typed(LEFT_KEY))
+            if ( (key_typed(RIGHT_KEY) && !key_typed(LEFT_KEY)) || 
+                 (key_typed(D_KEY) && !key_typed(A_KEY)))
             {
                 m_isSlidingRight = true;
                 // Next button becomes current button.
@@ -49,8 +51,8 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
     }
     else 
     {
-        // Move the selector up.
-        if (key_typed(UP_KEY))
+       // Move the selector up.
+        if (key_typed(UP_KEY) || key_typed(W_KEY))
         {
             // Previous button becomes current button.
             buttonNode = buttonNode->getPrev();
@@ -60,7 +62,7 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
             sprite_set_y(this->m_cursorSprite, sprite_y(buttonNode->button->btn()));
         }
         // Move the selector down.
-        if (key_typed(DOWN_KEY))
+        if (key_typed(DOWN_KEY) || key_typed(S_KEY))
         {
             // next button becomes current button.
             buttonNode = buttonNode->getNext();
@@ -87,13 +89,13 @@ std::string Selector::checkForSelection(ButtonNode* buttonNode, bool isFromGameM
     if (!isFromGameMenu)
     {
         // Return key returns the action of the selected button.
-        if (key_typed(RETURN_KEY)) 
+        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY)) 
             return buttonNode->button->action();
     }
     else
     {
-        // Return key returns the action of the selected button.
-        if (key_typed(RETURN_KEY)) 
+         // Return key returns the action of the selected button.
+        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY) ) 
             return buttonNode->button->action("return");
 
         // Escape key returns the action of the selected button.


### PR DESCRIPTION
## Arcade Machine Button Mappings
This PR allows Arcade Machine player 1 & 2 to navigate the main and games menus through the addition of the intended keyboard-to-arcade-button mappings to the Selector. There may be more changes necessary in the same vein, but for now this does suffice.