### PR TITLE
Feature/clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
 # BasedOnStyle:  Microsoft
-AccessModifierOffset: -2
+AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignArrayOfStructures: None
 AlignConsecutiveMacros: None

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,192 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Microsoft
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: MultiLine
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      true
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: true
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: BinPack
+BasedOnStyle:    ''
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: false
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 4
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 1000
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Right
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+  - NS_SWIFT_NAME
+  - CF_SWIFT_NAME
+...
+

--- a/.clang-format
+++ b/.clang-format
@@ -33,8 +33,8 @@ BraceWrapping:
   AfterClass:      true
   AfterControlStatement: Never
   AfterEnum:       false
-  AfterFunction:   false
-  AfterNamespace:  false
+  AfterFunction:   true
+  AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     false
   AfterUnion:      false

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 INCDIRS = -Iinclude
 CXX = skm g++ $(INCDIRS)
 src = $(wildcard src/*.cpp)
+headers = $(wildcard include/*.h)
 obj = $(src:.cpp=.o)
 
 LDFLAGS = -std=c++14
@@ -21,3 +22,7 @@ ArcadeMachine: $(obj)
 
 clean:
 	rm $(obj)
+
+format:
+	clang-format -i $(src)
+	clang-format -i $(headers)

--- a/README.md
+++ b/README.md
@@ -17,9 +17,15 @@ cd arcade-machine
 make
 ./ArcadeMachine
 ```
-
 Subsequent builds (as you change code) can be completed by using just `make`. If you need to run a clean build again, you can use `make clean` first proceeded by `make`.
 
 ## Building arcade machine (manually)
 + Compile the application with the command ```skm clang++ src/* -Iinclude -lstdc++fs -o test```  
 + Run the application ```./test```
+
+## Contributing code and running the code formatter
+Have a read of [CONTRIBUTING.md](CONTRIBUTING.md) to see the general code style conventions followed throughout the project.
+
+Automatic code formatting is supported using `clang-format` (you may need to install this if you want to use it). 
+
+To run the code formatter on the whole project, execute `make format`.

--- a/include/ArcadeMachine.h
+++ b/include/ArcadeMachine.h
@@ -12,29 +12,29 @@
 #define ARCADE_MACHINE_RES_Y 1080 * ARCADE_MACHINE_SCALING_FACTOR
 
 // Arcade Machine Class
+#include "Audio.h"
 #include "Button.h"
-#include "MenuButton.h"
-#include "GameScreenButton.h"
 #include "ButtonNode.h"
-#include "ConfigData.h"
-#include "GridLayout.h"
 #include "Cell.h"
+#include "ConfigData.h"
+#include "GameScreenButton.h"
+#include "GridLayout.h"
 #include "Helper.h"
 #include "Menu.h"
+#include "MenuButton.h"
 #include "Option.h"
-#include "Audio.h"
-#include "Splashscreen.h"
 #include "Selector.h"
+#include "Splashscreen.h"
 #include "splashkit.h"
+#include <fstream>
 #include <string>
 #include <vector>
-#include <fstream>
 
 // Define number of rows and columns in grid
 #define ROWS 7
 #define COLS 15
 
-/* 
+/*
     This class handles the creation of the
     Arcade Machine itself
 */
@@ -51,10 +51,10 @@ private:
     std::vector<ConfigData> m_configs;
 
     /// Vector of MenuButtons
-    std::vector<Button*> m_menuBtns;
+    std::vector<Button *> m_menuBtns;
 
     /// Vector of GameScreenButtons
-    std::vector<Button*> m_gameBtns;
+    std::vector<Button *> m_gameBtns;
 
     /// Thoth Tech Company intro
     Splashscreen m_introThothTech;
@@ -80,7 +80,7 @@ private:
     /// Mouse pointer
     point_2d m_mouse;
 
-    /// Button Action 
+    /// Button Action
     std::string m_action;
 
     /// Turn menu music on/off
@@ -91,10 +91,11 @@ private:
 
     // Helper function to load developer names into m_arcadeTeamDeveloperNames
     // Called in the constructor
-    void loadDeveloperNames(const char* filePath);
+    void loadDeveloperNames(const char *filePath);
 
-    /// Check for Options menu exit 
+    /// Check for Options menu exit
     bool m_exitOptions = false;
+
 public:
     // Default Constructor
     ArcadeMachine();
@@ -103,11 +104,14 @@ public:
     ~ArcadeMachine();
 
     // Getters
-    auto get_configs() const -> const vector<ConfigData>& { return this->m_configs; }
+    auto get_configs() const -> const vector<ConfigData> &
+    {
+        return this->m_configs;
+    }
 
-    void mainMenu(); // Starts the Main Menu
-    void gamesMenu(); // Starts the Games Menu
-    void optionsMenu(); // Starts the Options Menu
+    void mainMenu();                    // Starts the Main Menu
+    void gamesMenu();                   // Starts the Games Menu
+    void optionsMenu();                 // Starts the Options Menu
     void buttonClicked(point_2d point); // Checks for buttons clicked
     void drawMainMenu();
     void prepareMainMenu();
@@ -116,7 +120,6 @@ public:
     void playSplashKitIntro(); // Draws the Splashkit Productions logo to the screen and fetches new games from Git repo
     void printConfigs();
     void exitProgram();
-
 };
 
 #endif

--- a/include/Audio.h
+++ b/include/Audio.h
@@ -1,72 +1,73 @@
 #ifndef ARCADE_MACHINE_AUDIO_H
 #define ARCADE_MACHINE_AUDIO_H
 
+#include "splashkit.h"
 #include <string>
 
-class Audio {
-    private:
-        vector<music> m_music;
-        int songId;
-    public:
-        Audio()
-        {
-            getAllMusic();
-        }
+class Audio
+{
+private:
+    vector<music> m_music;
+    int songId;
 
-        void setSongId(int id)
-        {
-            this->songId = id;
-        }
+public:
+    Audio()
+    {
+        getAllMusic();
+    }
 
-        void playMusic(float volume)
-        {
-            play_music(m_music[0]);
-            set_music_volume(volume);
-            setSongId(0);
-        }
+    void setSongId(int id)
+    {
+        this->songId = id;
+    }
 
-        void playMusic(std::string song, float volume)
-        {
-            play_music(song);
-            set_music_volume(volume);
-            music thisSong = music_named(song);
+    void playMusic(float volume)
+    {
+        play_music(m_music[0]);
+        set_music_volume(volume);
+        setSongId(0);
+    }
 
-            for (int i = 0; i < this->m_music.size(); i++)
-            {
-                if (thisSong == this->m_music[i])
-                {
-                    write_line("same song");
-                    setSongId(i);
-                }
+    void playMusic(std::string song, float volume)
+    {
+        play_music(song);
+        set_music_volume(volume);
+        music thisSong = music_named(song);
+
+        for (int i = 0; i < this->m_music.size(); i++) {
+            if (thisSong == this->m_music[i]) {
+                write_line("same song");
+                setSongId(i);
             }
         }
+    }
 
-        void playMusic(int _currentMusic, float volume)
-        {
-            play_music(std::to_string(_currentMusic));
-            set_music_volume(volume);
-        }
+    void playMusic(int _currentMusic, float volume)
+    {
+        play_music(std::to_string(_currentMusic));
+        set_music_volume(volume);
+    }
 
-        void playNextSong()
-        {
-            if (this->songId != (this->m_music.size() - 1))
-                play_music(this->m_music[this->songId + 1]);
-            else
-                play_music(this->m_music[0]);
-        }
+    void playNextSong()
+    {
+        if (this->songId != (this->m_music.size() - 1))
+            play_music(this->m_music[this->songId + 1]);
+        else
+            play_music(this->m_music[0]);
+    }
 
-        void setVolume(float volume)
-        {
-            set_music_volume(volume);
-        }
+    void setVolume(float volume)
+    {
+        set_music_volume(volume);
+    }
 
-        void getAllMusic()
-        {
-            m_music.push_back(music_named("music_mainmenu"));
-            m_music.push_back(music_named("1"));
-            m_music.push_back(music_named("2"));
-            m_music.push_back(music_named("3"));
-        }
+    void getAllMusic()
+    {
+        m_music.push_back(music_named("music_mainmenu"));
+        m_music.push_back(music_named("1"));
+        m_music.push_back(music_named("2"));
+        m_music.push_back(music_named("3"));
+    }
 };
 
 #endif

--- a/include/Button.h
+++ b/include/Button.h
@@ -1,14 +1,14 @@
 #ifndef ARCADE_MACHINE_BUTTON_H
 #define ARCADE_MACHINE_BUTTON_H
 
-#include <string>
 #include "splashkit.h"
+#include <string>
 
 /**
  * @brief Abstract Button Class
- * 
+ *
  * This abstract class is the base class for all derived classes
- * Contains three overloaded contructors and three virtual methods 
+ * Contains three overloaded contructors and three virtual methods
  */
 class Button
 {
@@ -26,7 +26,7 @@ public:
     point_2d m_btnLocation;
 
     /// This buttons position in the window in pixels
-    int m_x; 
+    int m_x;
     int m_y;
 
     /// This buttons centre point offset width in pixels
@@ -46,30 +46,65 @@ public:
     std::string m_imagePath;
 
     /// Getters:
-    auto id()       const -> const int&         { return m_id;          }
-    auto pic()      const -> const bitmap&      { return m_pic;         }
-    auto btn()      const -> const sprite&      { return m_btn;         }
-    auto location() const -> const point_2d&    { return m_btnLocation; }
-    auto x()        const -> const int&         { return m_x;           }
-    auto y()        const -> const int&         { return m_y;           }
-    auto centreX()  const -> const int&         { return m_centreX;     }
-    auto centreY()  const -> const int&         { return m_centreY;     }
-    auto color()    const -> const std::string& { return m_btnColor;    }
+    auto id() const -> const int &
+    {
+        return m_id;
+    }
+    auto pic() const -> const bitmap &
+    {
+        return m_pic;
+    }
+    auto btn() const -> const sprite &
+    {
+        return m_btn;
+    }
+    auto location() const -> const point_2d &
+    {
+        return m_btnLocation;
+    }
+    auto x() const -> const int &
+    {
+        return m_x;
+    }
+    auto y() const -> const int &
+    {
+        return m_y;
+    }
+    auto centreX() const -> const int &
+    {
+        return m_centreX;
+    }
+    auto centreY() const -> const int &
+    {
+        return m_centreY;
+    }
+    auto color() const -> const std::string &
+    {
+        return m_btnColor;
+    }
 
     /// Setters
-    void setId(int id)      { this->m_id = id; }
-    void setX(const int &x) { this->m_x  = x;  }
-    void setY(const int &y) { this->m_y  = y;  }
+    void setId(int id)
+    {
+        this->m_id = id;
+    }
+    void setX(const int &x)
+    {
+        this->m_x = x;
+    }
+    void setY(const int &y)
+    {
+        this->m_y = y;
+    }
 
     /**
-    * @brief Enumeration of button types
-    * 
-    */
-    enum Color
-    {
+     * @brief Enumeration of button types
+     *
+     */
+    enum Color {
         PLAY,
         EXIT,
-        OPTS, 
+        OPTS,
         GAME,
         HOME,
         SOUND,
@@ -78,13 +113,17 @@ public:
     };
 
     // Default Constructor
-    Button() {}
+    Button()
+    {
+    }
     Button(Color c, float scale = 1);
     Button(Color c, float x, float y, int xCell, int yCell, float scale = 1);
     Button(Color c, std::string image, float scale = 1);
 
     // Destructor
-    virtual ~Button() {}
+    virtual ~Button()
+    {
+    }
 
     // Virtual fucntions
     virtual void btnImage(std::string image) = 0;
@@ -92,7 +131,6 @@ public:
     virtual std::string action(std::string keyinput = "") = 0;
 
     std::string btn_color(Color c);
-
 };
 
 #endif

--- a/include/ButtonNode.h
+++ b/include/ButtonNode.h
@@ -1,8 +1,8 @@
 #ifndef ARCADE_MACHINE_BUTTON_NODE_H
 #define ARCADE_MACHINE_BUTTON_NODE_H
 
-#include "ConfigData.h"
 #include "Button.h"
+#include "ConfigData.h"
 #include "GameData.h"
 
 class ButtonNode
@@ -18,7 +18,7 @@ public:
 
     /**
      * @brief construct a new Button Node object
-     * 
+     *
      * @param button the button to be stored in the node
      */
     ButtonNode(Button *button)
@@ -30,7 +30,7 @@ public:
 
     /**
      * @brief construct a new Button Node object
-     * 
+     *
      * @param button the button to be stored in the node
      * @param next the next node
      * @param prev the previous node
@@ -44,7 +44,7 @@ public:
 
     /**
      * @brief add a node after the current node
-     * 
+     *
      * @param button the button to be linked to the node
      */
     void addAfter(ButtonNode *node)
@@ -57,7 +57,7 @@ public:
 
     /**
      * @brief add a node before the current node
-     * 
+     *
      * @param button the button to be linked to the node
      */
     void addBefore(ButtonNode *node)
@@ -70,7 +70,7 @@ public:
 
     /**
      * @brief remove this node from the list
-     * 
+     *
      */
     void remove()
     {
@@ -80,17 +80,17 @@ public:
 
     /**
      * @brief get the next node in the list
-     * 
+     *
      * @return ButtonNode* the next node in the list
      */
     ButtonNode *getNext()
     {
         return this->m_next;
     }
-    
+
     /**
      * @brief get the previous node in the list
-     * 
+     *
      * @return ButtonNode* the previous node in the list
      */
     ButtonNode *getPrev()

--- a/include/Cell.h
+++ b/include/Cell.h
@@ -1,8 +1,7 @@
 #ifndef ARCADE_MACHINE_CELL_H
 #define ARCADE_MACHINE_CELL_H
 
-enum item
-{
+enum item {
     EMPTY,
     BMP,
     SPT,

--- a/include/ConfigData.h
+++ b/include/ConfigData.h
@@ -1,14 +1,14 @@
 #ifndef ARCADE_MACHINE_CONFIG_DATA_H
 #define ARCADE_MACHINE_CONFIG_DATA_H
 
-#include <vector>
-#include <fstream>
 #include "splashkit.h"
+#include <fstream>
+#include <vector>
 
 /**
-* @brief Parses the configuration data from config.txt files to a data object
-* 
-*/
+ * @brief Parses the configuration data from config.txt files to a data object
+ *
+ */
 class ConfigData
 {
 private:
@@ -18,10 +18,10 @@ private:
     /// The repository
     std::string m_repo;
 
-    /// This programming language this game was written in 
+    /// This programming language this game was written in
     std::string m_language;
 
-    /// The thumbnail image of this game  
+    /// The thumbnail image of this game
     std::string m_image;
 
     /// The title of this game
@@ -30,7 +30,7 @@ private:
     /// The genre of this game
     std::string m_genre;
 
-    /// The MPA classification rating of this game 
+    /// The MPA classification rating of this game
     std::string m_rating;
 
     /// Th author/creator of this game
@@ -48,41 +48,87 @@ private:
     /// The folder this game is inside
     std::string m_folder;
 
-    /// A descritpion of the game 
+    /// A descritpion of the game
     std::string m_description;
 
 public:
-    ConfigData() {}
+    ConfigData()
+    {
+    }
     ConfigData(std::string configFile);
 
-    //Setters:
-    auto setId(int &i) { m_id = i; }
-    auto setFolder(std::string &dir) { m_folder = dir; }
+    // Setters:
+    auto setId(int &i)
+    {
+        m_id = i;
+    }
+    auto setFolder(std::string &dir)
+    {
+        m_folder = dir;
+    }
     // Getters:
-    auto id()            const -> const int&         { return m_id;            }
-    auto repo()          const -> const std::string& { return m_repo;          }
-    auto language()      const -> const std::string& { return m_language;      }
-    auto image()         const -> const std::string& { return m_image;         }
-    auto title()         const -> const std::string& { return m_title;         }
-    auto genre()         const -> const std::string& { return m_genre;         }
-    auto rating()        const -> const std::string& { return m_rating;        }
-    auto author()        const -> const std::string& { return m_author;        }
-    auto win_exe()       const -> const std::string& { return m_win_exe;       }
-    auto lin_exe()       const -> const std::string& { return m_lin_exe;       }
-    auto mac_exe()       const -> const std::string& { return m_mac_exe;       }
-    auto folder()        const -> const std::string& { return m_folder;        }
-    auto description()   const -> const std::string& { return m_description;   }
+    auto id() const -> const int &
+    {
+        return m_id;
+    }
+    auto repo() const -> const std::string &
+    {
+        return m_repo;
+    }
+    auto language() const -> const std::string &
+    {
+        return m_language;
+    }
+    auto image() const -> const std::string &
+    {
+        return m_image;
+    }
+    auto title() const -> const std::string &
+    {
+        return m_title;
+    }
+    auto genre() const -> const std::string &
+    {
+        return m_genre;
+    }
+    auto rating() const -> const std::string &
+    {
+        return m_rating;
+    }
+    auto author() const -> const std::string &
+    {
+        return m_author;
+    }
+    auto win_exe() const -> const std::string &
+    {
+        return m_win_exe;
+    }
+    auto lin_exe() const -> const std::string &
+    {
+        return m_lin_exe;
+    }
+    auto mac_exe() const -> const std::string &
+    {
+        return m_mac_exe;
+    }
+    auto folder() const -> const std::string &
+    {
+        return m_folder;
+    }
+    auto description() const -> const std::string &
+    {
+        return m_description;
+    }
 
     std::ifstream openFile(std::string file);
     std::vector<std::string> readTxt(std::ifstream file);
     void collectConfigData(std::vector<std::string> configs = std::vector<std::string>());
     json readJson(std::string filepath);
     void collectJsonData(json json_configs = {});
-    bool getFromGit(std::string url, const char* dir);
-    void renameDir(const char* dir);
+    bool getFromGit(std::string url, const char *dir);
+    void renameDir(const char *dir);
     void deleteDir(std::string dir);
     void printConfigData();
-
 };
 
 #endif

--- a/include/Database.h
+++ b/include/Database.h
@@ -1,463 +1,473 @@
 #ifndef ARCADE_MACHINE_DATABASE_H
 #define ARCADE_MACHINE_DATABASE_H
 
-#include <iostream>
-#include <string>
-#include <vector>
-#include "splashkit.h"
 #include "Table.h"
+#include "splashkit.h"
+#include <iostream>
 #include <map>
+#include <string>
 #include <tuple>
+#include <vector>
 
-class Database {
-    private:
-        std::string m_databaseName;
-        std::string m_databaseFileName;
-        std::vector<Table*> m_tables;
+class Database
+{
+private:
+    std::string m_databaseName;
+    std::string m_databaseFileName;
+    std::vector<Table *> m_tables;
 
-    public:
-        // Constructors
-        Database(){
-            m_databaseName = "arcadeMachine";
-            m_databaseFileName = "arcadeMachine.db";
-            database db = open_database(m_databaseName, m_databaseFileName);
-            free_database(db);
-        };
+public:
+    // Constructors
+    Database()
+    {
+        m_databaseName = "arcadeMachine";
+        m_databaseFileName = "arcadeMachine.db";
+        database db = open_database(m_databaseName, m_databaseFileName);
+        free_database(db);
+    };
 
-        Database(std::string databaseName, std::string databaseFileName){
-            m_databaseName = databaseName;
-            m_databaseFileName = databaseFileName;
-            database db = open_database(m_databaseName, m_databaseFileName);
-            free_database(db);
-        };
+    Database(std::string databaseName, std::string databaseFileName)
+    {
+        m_databaseName = databaseName;
+        m_databaseFileName = databaseFileName;
+        database db = open_database(m_databaseName, m_databaseFileName);
+        free_database(db);
+    };
 
-        ~Database()
-        {
-            std::cout << "Destructor called on database: \"" << m_databaseName << "\"\n";
-            std::cout << "Database: Clearing table memory...\n";
-            for (auto& table : m_tables) delete table;
-            m_tables.clear();
+    ~Database()
+    {
+        std::cout << "Destructor called on database: \"" << m_databaseName << "\"\n";
+        std::cout << "Database: Clearing table memory...\n";
+        for (auto &table : m_tables)
+            delete table;
+        m_tables.clear();
+    }
+
+    // Getters
+    std::string getDatabaseName()
+    {
+        return m_databaseName;
+    };
+
+    std::string getDatabaseFileName()
+    {
+        return m_databaseFileName;
+    };
+
+    std::vector<Table *> getTables()
+    {
+        return m_tables;
+    };
+
+    // Methods
+
+    // Creates a new table if it doesn't exist
+    bool createTable(Table *table)
+    {
+        database db = open_database(m_databaseName, m_databaseFileName);
+
+        // Add the table to the Databases vector of tables
+        m_tables.push_back(table);
+
+        // Create the query
+        std::string createTable = "CREATE TABLE IF NOT EXISTS " + table->getTableName() + " (";
+        std::map<std::string, std::string> columnNames = table->getColumnNames();
+        for (auto const &pair : columnNames) {
+            createTable += pair.first + " " + pair.second + ", ";
         }
+        createTable = createTable.substr(0, createTable.size() - 2);
+        createTable += ")";
 
-        // Getters
-        std::string getDatabaseName(){
-            return m_databaseName;
-        };
+        // Execute the query
+        query_result res = run_sql(db, createTable);
 
-        std::string getDatabaseFileName(){
-            return m_databaseFileName;
-        };
+        free_database(db);
 
-        std::vector<Table*> getTables(){
-            return m_tables;
-        };
+        // Return true if the table was created
+        if (query_success(res)) {
+            std::cout << "Table created successfully" << std::endl;
+            free_all_query_results();
+            return true;
+        } else { // Return false if the table was not created
+            std::cout << "Table creation failed" << std::endl;
+            std::cout << createTable << std::endl;
+            free_all_query_results();
+            return false;
+        }
+    };
 
+    // Inserts a new row into a table
+    bool insertData(std::string tableName, std::map<std::string, std::string> data)
+    {
+        // Check if table exists
+        bool exists = std::get<0>(hasTable(tableName));
 
-        // Methods
-
-        // Creates a new table if it doesn't exist
-        bool createTable(Table *table){
+        if (exists) {
             database db = open_database(m_databaseName, m_databaseFileName);
-
-            // Add the table to the Databases vector of tables
-            m_tables.push_back(table);
 
             // Create the query
-            std::string createTable = "CREATE TABLE IF NOT EXISTS " + table->getTableName() + " (";
-            std::map<std::string, std::string> columnNames = table->getColumnNames();
-            for (auto const& pair : columnNames) {
-                createTable += pair.first + " " + pair.second + ", ";
+            std::string insertData = "INSERT INTO " + tableName + " (";
+            for (auto const &pair : data) {
+                insertData += pair.first + ", ";
             }
-            createTable = createTable.substr(0, createTable.size() - 2);
-            createTable += ")";
+            insertData = insertData.substr(0, insertData.size() - 2);
+            insertData += ") VALUES (";
+
+            for (auto const &pair : data) {
+                insertData += "'" + pair.second + "', ";
+            }
+            insertData = insertData.substr(0, insertData.size() - 2);
+            insertData += ")";
 
             // Execute the query
-            query_result res = run_sql(db, createTable);
-
+            query_result res = run_sql(db, insertData);
             free_database(db);
 
-            // Return true if the table was created
+            // Return true if the row was inserted
             if (query_success(res)) {
-                std::cout << "Table created successfully" << std::endl;
+                std::cout << "Data inserted successfully" << std::endl;
                 free_all_query_results();
                 return true;
-            } else { // Return false if the table was not created
-                std::cout << "Table creation failed" << std::endl;
-                std::cout << createTable << std::endl;
+            } else { // Return false if the row was not inserted
+                std::cout << "Data insertion failed" << std::endl;
+                std::cout << insertData << std::endl;
                 free_all_query_results();
                 return false;
             }
-        };
+        } else { // Return false if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return false;
+        }
+    };
 
-        // Inserts a new row into a table
-        bool insertData(std::string tableName, std::map<std::string, std::string> data){
-            // Check if table exists
-            bool exists = std::get<0>(hasTable(tableName));
+    // Returns a vector of vectors of strings containing the data in the table
+    std::vector<std::vector<std::string>> getAllData(std::string tableName)
+    {
+        // Check if table exists
+        std::tuple<bool, Table *> tableExists = hasTable(tableName);
 
-            if (exists) {
-                database db = open_database(m_databaseName, m_databaseFileName);
+        bool exists = std::get<0>(tableExists);
 
-                // Create the query
-                std::string insertData = "INSERT INTO " + tableName + " (";
-                for (auto const& pair : data) {
-                    insertData += pair.first + ", ";
-                }
-                insertData = insertData.substr(0, insertData.size() - 2);
-                insertData += ") VALUES (";
+        Table *table = std::get<1>(tableExists);
 
-                for (auto const& pair : data) {
-                    insertData += "'" + pair.second + "', ";
-                }
-                insertData = insertData.substr(0, insertData.size() - 2);
-                insertData += ")";
+        if (exists) {
+            std::vector<std::vector<string>> data;
+            database db = open_database(m_databaseName, m_databaseFileName);
 
-                // Execute the query
-                query_result res = run_sql(db, insertData);
-                free_database(db);
+            // Create the query
+            string query = "SELECT * FROM " + tableName;
 
-                // Return true if the row was inserted
-                if (query_success(res)) {
-                    std::cout << "Data inserted successfully" << std::endl;
-                    free_all_query_results();
-                    return true;
-                } else { // Return false if the row was not inserted
-                    std::cout << "Data insertion failed" << std::endl;
-                    std::cout << insertData << std::endl;
-                    free_all_query_results();
-                    return false;
-                }
-            } else { // Return false if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return false;
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            // Add the column names to the data vector first
+            std::vector<std::string> columnNames;
+            for (auto const &pair : table->getColumnNames()) {
+                columnNames.push_back(pair.first);
             }
-        };
+            data.push_back(columnNames);
 
+            // Add the data to the data vector
+            while (has_row(res)) {
+                // Get each row as a vector of strings
+                std::vector<std::string> row = get_current_row_strings(res);
 
-        // Returns a vector of vectors of strings containing the data in the table
-        std::vector<std::vector<std::string>> getAllData(std::string tableName){
-            // Check if table exists
-            std::tuple<bool, Table*> tableExists = hasTable(tableName);
+                data.push_back(row);
 
-            bool exists = std::get<0>(tableExists);
-
-            Table *table = std::get<1>(tableExists);
-
-            if (exists) {
-                std::vector<std::vector<string>> data;
-                database db = open_database(m_databaseName, m_databaseFileName);
-
-                // Create the query
-                string query = "SELECT * FROM " + tableName;
-
-                // Execute the query
-                query_result res = run_sql(db, query);
-
-                // Add the column names to the data vector first
-                std::vector<std::string> columnNames;
-                for (auto const& pair: table->getColumnNames()) {
-                    columnNames.push_back(pair.first);
+                if (!get_next_row(res)) {
+                    break;
                 }
-                data.push_back(columnNames);
-
-                // Add the data to the data vector
-                while (has_row(res)) {
-                    // Get each row as a vector of strings
-                    std::vector<std::string> row = get_current_row_strings(res);
-
-                    data.push_back(row);
-
-                    if (!get_next_row(res)) {
-                        break;
-                    }
-                }
-
-                // Return the data
-                if (query_success(res)) {
-                    std::cout << "Data returned successfully" << std::endl;
-                } else {
-                    std::cout << "Data return failed" << std::endl;
-                    std::cout << query << std::endl;
-                }
-                free_database(db);
-                free_all_query_results();
-                return data;
-
-            } else { // Return an empty vector if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return std::vector<std::vector<std::string>>() ;
             }
-        };
 
-        // Prints the all data in the table to the console
-        bool printAllData(std::string tableName){
-            // Check if table exists
-            std::tuple<bool, Table*> tableExists = hasTable(tableName);
+            // Return the data
+            if (query_success(res)) {
+                std::cout << "Data returned successfully" << std::endl;
+            } else {
+                std::cout << "Data return failed" << std::endl;
+                std::cout << query << std::endl;
+            }
+            free_database(db);
+            free_all_query_results();
+            return data;
 
-            bool exists = std::get<0>(tableExists);
+        } else { // Return an empty vector if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return std::vector<std::vector<std::string>>();
+        }
+    };
 
-            Table *table = std::get<1>(tableExists);
+    // Prints the all data in the table to the console
+    bool printAllData(std::string tableName)
+    {
+        // Check if table exists
+        std::tuple<bool, Table *> tableExists = hasTable(tableName);
 
+        bool exists = std::get<0>(tableExists);
 
-            if (exists) {
+        Table *table = std::get<1>(tableExists);
 
-                database db = open_database(m_databaseName, m_databaseFileName);
+        if (exists) {
 
-                // Create the query
-                string query = "SELECT * FROM " + tableName;
+            database db = open_database(m_databaseName, m_databaseFileName);
 
-                // Execute the query
-                query_result res = run_sql(db, query);
+            // Create the query
+            string query = "SELECT * FROM " + tableName;
 
-                // Print the column names
-                for (auto const& pair: table->getColumnNames()) {
-                    std::cout << pair.first  // string (key)
-                            << ':'
-                            << pair.second
-                            << " | "; // string's value
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            // Print the column names
+            for (auto const &pair : table->getColumnNames()) {
+                std::cout << pair.first                   // string (key)
+                          << ':' << pair.second << " | "; // string's value
+            }
+            std::cout << std::endl;
+
+            // Print the data
+            while (has_row(res)) {
+                std::vector<std::string> row = get_current_row_strings(res);
+
+                for (int i = 0; i < row.size(); i++) {
+                    std::cout << row[i] << " | ";
                 }
                 std::cout << std::endl;
 
-                // Print the data
-                while (has_row(res)) {
-                    std::vector<std::string> row = get_current_row_strings(res);
-
-                    for (int i = 0; i < row.size(); i++) {
-                        std::cout << row[i] << " | ";
-                    }
-                    std::cout << std::endl;
-
-                    if (!get_next_row(res)) {
-                        break;
-                    }
+                if (!get_next_row(res)) {
+                    break;
                 }
-                free_database(db);
-
-                // Return true if the data was printed
-                if (query_success(res)) {
-                    std::cout << "Data printed successfully" << std::endl;
-                    free_all_query_results();
-                    return true;
-                } else { // Return false if the data was not printed
-                    std::cout << "Data print failed" << std::endl;
-                    std::cout << query << std::endl;
-                    free_all_query_results();
-                    return false;
-                }
-            } else { // Return false if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return false;
             }
-        };
+            free_database(db);
 
-        // Returns a bool if a row was deleted
-        bool deleteData(std::string tableName, std::map<std::string, std::string> data){
-            // Check if table exists
-            bool exists = std::get<0>(hasTable(tableName));
-
-            if (exists) {
-                database db = open_database(m_databaseName, m_databaseFileName);
-
-                // Create the query
-                std::string query = "DELETE FROM " + tableName + " WHERE ";
-                for (auto const& pair : data) {
-                    query += pair.first + " = '" + pair.second + "' AND ";
-                }
-                query = query.substr(0, query.size() - 5);
-                query += ";";
-
-                // Execute the query
-                query_result res = run_sql(db, query);
-
-
-                free_database(db);
-
-                // Return true if the row was deleted
-                if (query_success(res)) {
-                    std::cout << "Data deleted successfully" << std::endl;
-                    free_all_query_results();
-                    return true;
-                } else { // Return false if the row was not deleted
-                    std::cout << "Data deletion failed" << std::endl;
-                    std::cout << query << std::endl;
-                    free_all_query_results();
-                    return false;
-                }
-            } else { //     Return false if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return false;
-            }
-
-        };
-
-        // Returns a bool if a row was updated
-        // The newData parameter is a map of column names to new values
-        // The conditionData parameter is a map of column names to values to be used in the WHERE clause
-
-        bool updateData(std::string tableName, std::map<std::string, std::string> newData, std::map<std::string, std::string> conditionData){
-            // Check if table exists
-            bool exists = std::get<0>(hasTable(tableName));
-
-            if (exists) {
-                database db = open_database(m_databaseName, m_databaseFileName);
-
-                // Create the query
-                std::string query = "UPDATE " + tableName + " SET ";
-                for (auto const& pair : newData) {
-                    query += pair.first + " = '" + pair.second + "', ";
-                }
-                query = query.substr(0, query.size() - 2);
-                query += " WHERE ";
-                for (auto const& pair : conditionData) {
-                    query += pair.first + " = '" + pair.second + "' AND ";
-                }
-                query = query.substr(0, query.size() - 5);
-                query += ";";
-
-                // Execute the query
-                query_result res = run_sql(db, query);
-
-                free_database(db);
-                // Return true if the row was updated
-                if (query_success(res)) {
-                    std::cout << "Data updated successfully" << std::endl;
-                    free_all_query_results();
-                    return true;
-                } else { // Return false if the row was not updated
-                    std::cout << "Data update failed" << std::endl;
-                    std::cout << query << std::endl;
-                    free_all_query_results();
-                    return false;
-                }
-            } else {   // Return false if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return false;
-            }
-        };
-
-        // Returns a bool if a table was dropped
-        bool dropTable(std::string tableName){
-            // Check if table exists
-            bool exists = std::get<0>(hasTable(tableName));
-            if (exists) {
-                database db = open_database(m_databaseName, m_databaseFileName);
-                // Create the query
-                std::string query = "DROP TABLE " + tableName;
-                // Execute the query
-                query_result res = run_sql(db, query);
-
-                free_database(db);
-                if (query_success(res)) { // Return true if the table was dropped
-                    std::cout << "Table dropped successfully" << std::endl;
-                    free_all_query_results();
-                    return true;
-                } else { // Return false if the table was not dropped
-                    std::cout << "Table drop failed" << std::endl;
-                    std::cout << query << std::endl;
-                    free_all_query_results();
-                    return false;
-                }
-            } else { // Return false if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return false;
-            }
-        };
-
-
-        // Returns a vector of vectors of strings containing the data matching a condition
-        // The conditionData parameter is a map of column names to values to be used in the WHERE clause
-        std::vector<std::vector<std::string>> getData(std::string tableName, std::map<std::string, std::string> conditionData){
-            // Check if table exists
-            std::tuple<bool, Table*> tableExists = hasTable(tableName);
-
-            bool exists = std::get<0>(tableExists);
-
-            Table *table = std::get<1>(tableExists);
-
-            if (exists) {
-                std::vector<std::vector<std::string>> data;
-                database db = open_database(m_databaseName, m_databaseFileName);
-
-                // Create the query
-                std::string query = "SELECT * FROM " + tableName + " WHERE ";
-                for (auto const& pair : conditionData) {
-                    query += pair.first + " = '" + pair.second + "' AND ";
-                }
-                query = query.substr(0, query.size() - 5);
-                query += ";";
-                // Execute the query
-                query_result res = run_sql(db, query);
-
-                // Add the column names to the data vector first
-                std::vector<std::string> columnNames;
-                for (auto const& pair: table->getColumnNames()) {
-                    columnNames.push_back(pair.first);
-                }
-                data.push_back(columnNames);
-
-                // Add the data to the data vector
-                while (has_row(res)) {
-                    // Get each row as a vector of strings
-                    std::vector<std::string> row = get_current_row_strings(res);
-
-                    data.push_back(row);
-
-                    if (!get_next_row(res)) {
-                        break;
-                    }
-                }
-
-                // Return the data
-                if (query_success(res)) {
-                    std::cout << "Data returned successfully" << std::endl;
-                } else {
-                    std::cout << "Data return failed" << std::endl;
-                    std::cout << query << std::endl;
-                }
-                free_database(db);
+            // Return true if the data was printed
+            if (query_success(res)) {
+                std::cout << "Data printed successfully" << std::endl;
                 free_all_query_results();
-                return data;
-            } else { // Return an empty vector if the table does not exist
-                std::cout << "Table does not exist" << std::endl;
-                return std::vector<std::vector<string>>();
+                return true;
+            } else { // Return false if the data was not printed
+                std::cout << "Data print failed" << std::endl;
+                std::cout << query << std::endl;
+                free_all_query_results();
+                return false;
             }
-        };
-
-        // Returns the current row as a vector of strings
-        std::vector<std::string> get_current_row_strings(query_result res) {
-            vector<string> row;
-            for (int i = 0; i < query_column_count(res); i++) {
-                row.push_back(query_column_for_string(res, i));
-            }
-            return row;
+        } else { // Return false if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return false;
         }
+    };
 
-        // Returns a tuple of a bool and a table if the table exists
-        std::tuple<bool, Table*> hasTable(std::string tableName){
+    // Returns a bool if a row was deleted
+    bool deleteData(std::string tableName, std::map<std::string, std::string> data)
+    {
+        // Check if table exists
+        bool exists = std::get<0>(hasTable(tableName));
 
-            // Check if table exists
-            std::tuple<bool, Table*> exists;
+        if (exists) {
+            database db = open_database(m_databaseName, m_databaseFileName);
 
-            for (int i= 0; i < m_tables.size(); i++){
-                if (m_tables[i]->getTableName() == tableName) {
-                    exists = std::make_tuple(true, m_tables[i]);
-                    return exists;
+            // Create the query
+            std::string query = "DELETE FROM " + tableName + " WHERE ";
+            for (auto const &pair : data) {
+                query += pair.first + " = '" + pair.second + "' AND ";
+            }
+            query = query.substr(0, query.size() - 5);
+            query += ";";
+
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            free_database(db);
+
+            // Return true if the row was deleted
+            if (query_success(res)) {
+                std::cout << "Data deleted successfully" << std::endl;
+                free_all_query_results();
+                return true;
+            } else { // Return false if the row was not deleted
+                std::cout << "Data deletion failed" << std::endl;
+                std::cout << query << std::endl;
+                free_all_query_results();
+                return false;
+            }
+        } else { //     Return false if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return false;
+        }
+    };
+
+    // Returns a bool if a row was updated
+    // The newData parameter is a map of column names to new values
+    // The conditionData parameter is a map of column names to values to be used in the WHERE clause
+
+    bool updateData(std::string tableName, std::map<std::string, std::string> newData,
+                    std::map<std::string, std::string> conditionData)
+    {
+        // Check if table exists
+        bool exists = std::get<0>(hasTable(tableName));
+
+        if (exists) {
+            database db = open_database(m_databaseName, m_databaseFileName);
+
+            // Create the query
+            std::string query = "UPDATE " + tableName + " SET ";
+            for (auto const &pair : newData) {
+                query += pair.first + " = '" + pair.second + "', ";
+            }
+            query = query.substr(0, query.size() - 2);
+            query += " WHERE ";
+            for (auto const &pair : conditionData) {
+                query += pair.first + " = '" + pair.second + "' AND ";
+            }
+            query = query.substr(0, query.size() - 5);
+            query += ";";
+
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            free_database(db);
+            // Return true if the row was updated
+            if (query_success(res)) {
+                std::cout << "Data updated successfully" << std::endl;
+                free_all_query_results();
+                return true;
+            } else { // Return false if the row was not updated
+                std::cout << "Data update failed" << std::endl;
+                std::cout << query << std::endl;
+                free_all_query_results();
+                return false;
+            }
+        } else { // Return false if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return false;
+        }
+    };
+
+    // Returns a bool if a table was dropped
+    bool dropTable(std::string tableName)
+    {
+        // Check if table exists
+        bool exists = std::get<0>(hasTable(tableName));
+        if (exists) {
+            database db = open_database(m_databaseName, m_databaseFileName);
+            // Create the query
+            std::string query = "DROP TABLE " + tableName;
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            free_database(db);
+            if (query_success(res)) { // Return true if the table was dropped
+                std::cout << "Table dropped successfully" << std::endl;
+                free_all_query_results();
+                return true;
+            } else { // Return false if the table was not dropped
+                std::cout << "Table drop failed" << std::endl;
+                std::cout << query << std::endl;
+                free_all_query_results();
+                return false;
+            }
+        } else { // Return false if the table does not exist
+            std::cout << "Table does not exist" << std::endl;
+            return false;
+        }
+    };
+
+    // Returns a vector of vectors of strings containing the data matching a condition
+    // The conditionData parameter is a map of column names to values to be used in the WHERE clause
+    std::vector<std::vector<std::string>> getData(std::string tableName,
+                                                  std::map<std::string, std::string> conditionData)
+    {
+        // Check if table exists
+        std::tuple<bool, Table *> tableExists = hasTable(tableName);
+
+        bool exists = std::get<0>(tableExists);
+
+        Table *table = std::get<1>(tableExists);
+
+        if (exists) {
+            std::vector<std::vector<std::string>> data;
+            database db = open_database(m_databaseName, m_databaseFileName);
+
+            // Create the query
+            std::string query = "SELECT * FROM " + tableName + " WHERE ";
+            for (auto const &pair : conditionData) {
+                query += pair.first + " = '" + pair.second + "' AND ";
+            }
+            query = query.substr(0, query.size() - 5);
+            query += ";";
+            // Execute the query
+            query_result res = run_sql(db, query);
+
+            // Add the column names to the data vector first
+            std::vector<std::string> columnNames;
+            for (auto const &pair : table->getColumnNames()) {
+                columnNames.push_back(pair.first);
+            }
+            data.push_back(columnNames);
+
+            // Add the data to the data vector
+            while (has_row(res)) {
+                // Get each row as a vector of strings
+                std::vector<std::string> row = get_current_row_strings(res);
+
+                data.push_back(row);
+
+                if (!get_next_row(res)) {
+                    break;
                 }
             }
 
+            // Return the data
+            if (query_success(res)) {
+                std::cout << "Data returned successfully" << std::endl;
+            } else {
+                std::cout << "Data return failed" << std::endl;
+                std::cout << query << std::endl;
+            }
+            free_database(db);
+            free_all_query_results();
+            return data;
+        } else { // Return an empty vector if the table does not exist
             std::cout << "Table does not exist" << std::endl;
-            exists = std::make_tuple(false, nullptr);
-            return exists;
-        };
-
-        //Query a database table with a specialised query.
-        //Returns query_result object.
-        query_result queryDatabase(database &db, std::string query)
-        {
-            db = open_database(m_databaseName, m_databaseFileName);
-            query_result res = run_sql(db, query);
-            return res;
+            return std::vector<std::vector<string>>();
         }
-};
+    };
 
+    // Returns the current row as a vector of strings
+    std::vector<std::string> get_current_row_strings(query_result res)
+    {
+        vector<string> row;
+        for (int i = 0; i < query_column_count(res); i++) {
+            row.push_back(query_column_for_string(res, i));
+        }
+        return row;
+    }
+
+    // Returns a tuple of a bool and a table if the table exists
+    std::tuple<bool, Table *> hasTable(std::string tableName)
+    {
+
+        // Check if table exists
+        std::tuple<bool, Table *> exists;
+
+        for (int i = 0; i < m_tables.size(); i++) {
+            if (m_tables[i]->getTableName() == tableName) {
+                exists = std::make_tuple(true, m_tables[i]);
+                return exists;
+            }
+        }
+
+        std::cout << "Table does not exist" << std::endl;
+        exists = std::make_tuple(false, nullptr);
+        return exists;
+    };
+
+    // Query a database table with a specialised query.
+    // Returns query_result object.
+    query_result queryDatabase(database &db, std::string query)
+    {
+        db = open_database(m_databaseName, m_databaseFileName);
+        query_result res = run_sql(db, query);
+        return res;
+    }
+};
 
 #endif

--- a/include/GameData.h
+++ b/include/GameData.h
@@ -1,284 +1,311 @@
 #ifndef ARCADE_MACHINE_GAME_DATA_H
 #define ARCADE_MACHINE_GAME_DATA_H
 
+#include "Database.h"
+#include "splashkit.h"
 #include <iostream>
 #include <string>
-#include <vector>
-#include "splashkit.h"
-#include "Database.h"
 #include <tuple>
+#include <vector>
 
 #define TABLE_NAME "gameData"
 
 class GameData
 {
-    private:
-        string m_gameName;
-        int m_startTime;
-        int m_endTime;
-        int m_rating;
-        int m_highScore;
+private:
+    string m_gameName;
+    int m_startTime;
+    int m_endTime;
+    int m_rating;
+    int m_highScore;
 
-    public:
-        GameData(
-        ){
-            this->m_rating = 0;
+public:
+    GameData()
+    {
+        this->m_rating = 0;
+    }
+
+    // Constructor
+    GameData(string gameName, int startTime, int endTime, int rating, int highScore)
+    {
+        m_gameName = gameName;
+        m_startTime = startTime;
+        m_endTime = endTime;
+        m_rating = rating;
+        m_highScore = highScore;
+    };
+    // Destructor
+    ~GameData(){};
+
+    // Setters
+    void setGameName(string gameName)
+    {
+        m_gameName = gameName;
+    }
+    void setStartTime(int start_time)
+    {
+        m_startTime = start_time;
+    }
+    void setEndTime(int end_time)
+    {
+        m_endTime = end_time;
+    }
+    void setRating(int rating)
+    {
+        m_rating = rating;
+    }
+    void setHighScore(int high_score)
+    {
+        m_highScore = high_score;
+    }
+
+    // Getters
+    string getGameName()
+    {
+        return m_gameName;
+    }
+    int getStartTime()
+    {
+        return m_startTime;
+    }
+    int getEndTime()
+    {
+        return m_endTime;
+    }
+    int getRating()
+    {
+        return m_rating;
+    }
+    int getHighScore()
+    {
+        return m_highScore;
+    }
+
+    // Creates a new table if it doesn't exist
+    // Writes the objects data to the table
+
+    // Useage:
+    // GameData data = GameData("gameName", startTime, endTime, rating, highScore);
+    // data.writeData(db);
+    void writeData(Database *db)
+    {
+        // Create a new row
+
+        std::map<std::string, std::string> row = {{"gameName", m_gameName},
+                                                  {"startTime", std::to_string(m_startTime)},
+                                                  {"endTime", std::to_string(m_endTime)},
+                                                  {"rating", std::to_string(m_rating)},
+                                                  {"highScore", std::to_string(m_highScore)}};
+        // Insert the row into the table
+        db->insertData(TABLE_NAME, row);
+    }
+
+    // Returns all data from the database as a vector of GameData objects
+
+    // Useage:
+    // GameData gameData = GameData();
+    // vector<GameData> data = gameData.readAllGameData(db);
+    vector<GameData> readAllGameData(Database *db)
+    {
+        // Get all data from the table
+        std::vector<std::vector<string>> data;
+        data = db->getAllData(TABLE_NAME);
+
+        if (data.size() < 1) {
+            std::cout << "No data in table" << std::endl;
+            return vector<GameData>();
         }
+        return formatData(data);
+    }
 
-        // Constructor
-        GameData(string gameName, int startTime, int endTime, int rating, int highScore) {
-            m_gameName = gameName;
-            m_startTime = startTime;
-            m_endTime = endTime;
-            m_rating = rating;
-            m_highScore = highScore;
-        };
-        // Destructor
-        ~GameData(){};
+    // enum and hash function for the swiitch statement in formatData
+    enum string_code {
+        eGameName,
+        eStartTime,
+        eEndTime,
+        eRating,
+        eHighScore
+    };
 
-        // Setters
-        void setGameName(string gameName) { m_gameName = gameName; }
-        void setStartTime(int start_time) {m_startTime = start_time;}
-        void setEndTime(int end_time) {m_endTime = end_time;}
-        void setRating(int rating) {m_rating = rating;}
-        void setHighScore(int high_score) {m_highScore = high_score;}
-
-        // Getters
-        string getGameName() {return m_gameName;}
-        int getStartTime() {return m_startTime;}
-        int getEndTime() {return m_endTime;}
-        int getRating() {return m_rating;}
-        int getHighScore() {return m_highScore;}
-
-
-        // Creates a new table if it doesn't exist
-        // Writes the objects data to the table
-
-        // Useage:
-        // GameData data = GameData("gameName", startTime, endTime, rating, highScore);
-        // data.writeData(db);
-        void writeData(Database *db) {
-            // Create a new row
-
-            std::map<std::string, std::string> row = {
-                {"gameName", m_gameName},
-                {"startTime", std::to_string(m_startTime)},
-                {"endTime", std::to_string(m_endTime)},
-                {"rating", std::to_string(m_rating)},
-                {"highScore", std::to_string(m_highScore)}
-            };
-            // Insert the row into the table
-            db->insertData(TABLE_NAME, row);
-
+    string_code hashit(std::string const &inString)
+    {
+        if (inString == "gameName") {
+            return eGameName;
+        } else if (inString == "startTime") {
+            return eStartTime;
+        } else if (inString == "endTime") {
+            return eEndTime;
+        } else if (inString == "rating") {
+            return eRating;
+        } else if (inString == "highScore") {
+            return eHighScore;
+        } else {
+            return eGameName;
         }
+    }
 
+    // Returns all data specific to a game from the database as a vector of GameData objects
 
-        // Returns all data from the database as a vector of GameData objects
+    // Useage:
+    // GameData gameData = GameData();
+    // vector<GameData> data = gameData.readGameData(db);
+    std::vector<GameData> readGameData(Database *db)
+    {
+        // Get all data from the table
+        std::vector<std::vector<string>> data;
 
-        // Useage:
-        // GameData gameData = GameData();
-        // vector<GameData> data = gameData.readAllGameData(db);
-        vector<GameData> readAllGameData(Database *db) {
-            // Get all data from the table
-            std::vector<std::vector<string>> data;
-            data = db->getAllData(TABLE_NAME);
+        std::map<std::string, std::string> where = {{"gameName", m_gameName}};
+        data = db->getData(TABLE_NAME, where);
 
-            if (data.size() < 1) {
-                std::cout << "No data in table" << std::endl;
-                return vector<GameData>();
-            }
-            return formatData(data);
-
+        if (data.size() < 1) {
+            std::cout << "No data in table" << std::endl;
+            return vector<GameData>();
         }
+        return formatData(data);
+    }
 
-        // enum and hash function for the swiitch statement in formatData
-        enum string_code {
-            eGameName,
-            eStartTime,
-            eEndTime,
-            eRating,
-            eHighScore
-        };
+    // Format the data for output
+    // Used in readAllGameData and readGameData
+    std::vector<GameData> formatData(std::vector<std::vector<string>> data)
+    {
+        // Create a vector of GameData objects
+        vector<GameData> gameData;
 
-        string_code hashit (std::string const& inString) {
-            if (inString == "gameName") {
-                return eGameName;
-            } else if (inString == "startTime") {
-                return eStartTime;
-            } else if (inString == "endTime") {
-                return eEndTime;
-            } else if (inString == "rating") {
-                return eRating;
-            } else if (inString == "highScore") {
-                return eHighScore;
-            } else {
-                return eGameName;
-            }
-        }
+        std::vector<string> columnNames = data[0];
 
-        // Returns all data specific to a game from the database as a vector of GameData objects
-
-        // Useage:
-        // GameData gameData = GameData();
-        // vector<GameData> data = gameData.readGameData(db);
-        std::vector<GameData> readGameData(Database *db) {
-            // Get all data from the table
-            std::vector<std::vector<string>> data;
-
-            std::map<std::string, std::string> where = {
-                {"gameName", m_gameName}
-            };
-            data = db->getData(TABLE_NAME, where);
-
-            if (data.size() < 1) {
-                std::cout << "No data in table" << std::endl;
-                return vector<GameData>();
-            }
-            return formatData(data);
-
-
-        }
-
-        // Format the data for output
-        // Used in readAllGameData and readGameData
-        std::vector<GameData> formatData(std::vector<std::vector<string>> data) {
-            // Create a vector of GameData objects
-            vector<GameData> gameData;
-
-            std::vector<string> columnNames = data[0];
-
-            for (int i = 1; i < data.size(); i++) {
-                std::vector<string> row = data[i];
-                GameData game;
-                for (int j = 0; j < row.size(); j++) {
-                    const char expression = hashit(columnNames[j]);
-                    switch (expression) {
-                        case eGameName:
-                            game.setGameName(row[j]);
-                            break;
-                        case eStartTime:
-                            game.setStartTime(std::stoi(row[j]));
-                            break;
-                        case eEndTime:
-                            game.setEndTime(std::stoi(row[j]));
-                            break;
-                        case eRating:
-                            game.setRating(std::stoi(row[j]));
-                            break;
-                        case eHighScore:
-                            game.setHighScore(std::stoi(row[j]));
-                            break;
-                        default:
-                            break;
-                    }
+        for (int i = 1; i < data.size(); i++) {
+            std::vector<string> row = data[i];
+            GameData game;
+            for (int j = 0; j < row.size(); j++) {
+                const char expression = hashit(columnNames[j]);
+                switch (expression) {
+                case eGameName:
+                    game.setGameName(row[j]);
+                    break;
+                case eStartTime:
+                    game.setStartTime(std::stoi(row[j]));
+                    break;
+                case eEndTime:
+                    game.setEndTime(std::stoi(row[j]));
+                    break;
+                case eRating:
+                    game.setRating(std::stoi(row[j]));
+                    break;
+                case eHighScore:
+                    game.setHighScore(std::stoi(row[j]));
+                    break;
+                default:
+                    break;
                 }
-                gameData.push_back(game);
             }
-            return gameData;
+            gameData.push_back(game);
         }
+        return gameData;
+    }
 
-        // Print GameData object
-        void printGameData() {
-            std::cout << "==== Game Data ====" << std::endl;
-            std::cout << "Game Name: " << m_gameName << std::endl;
-            std::cout << "Start Time: " << m_startTime << std::endl;
-            std::cout << "End Time: " << m_endTime << std::endl;
-            std::cout << "Rating: " << m_rating << std::endl;
-            std::cout << "High Score: " << m_highScore << std::endl;
-            std::cout << "==================" << std::endl;
+    // Print GameData object
+    void printGameData()
+    {
+        std::cout << "==== Game Data ====" << std::endl;
+        std::cout << "Game Name: " << m_gameName << std::endl;
+        std::cout << "Start Time: " << m_startTime << std::endl;
+        std::cout << "End Time: " << m_endTime << std::endl;
+        std::cout << "Rating: " << m_rating << std::endl;
+        std::cout << "High Score: " << m_highScore << std::endl;
+        std::cout << "==================" << std::endl;
+    }
+
+    // Returns the current row as a vector of strings
+    vector<string> get_current_row_strings(query_result res)
+    {
+        vector<string> row;
+        for (int i = 0; i < query_column_count(res); i++) {
+            row.push_back(query_column_for_string(res, i));
         }
+        return row;
+    }
 
-        // Returns the current row as a vector of strings
-        vector<string> get_current_row_strings(query_result res) {
-            vector<string> row;
-            for (int i = 0; i < query_column_count(res); i++) {
-                row.push_back(query_column_for_string(res, i));
+    // get the stats for a specific game
+    //  Average rating of a game
+    //  Total time played of a game in seconds (stored in both start and end time)
+    //  Max high score of a of game
+    GameData getStats(Database *db, string gameName)
+    {
+        GameData game = GameData();
+        database dataBase;
+        query_result result =
+            db->queryDatabase(dataBase, "SELECT gameName, AVG(rating) AS averageRating, SUM(endTime-startTime) AS "
+                                        "totalPlaytime, MAX(highScore) as highscore FROM gameData WHERE gameName='" +
+                                            gameName + "';");
+        if (query_success(result)) {
+            std::cout << "Query success" << std::endl;
+            if (has_row(result)) {
+                if (query_type_of_col(result, 0) == "NULL") {
+                    std::cout << "No data returned from query!" << std::endl;
+                    return game;
+                }
+                game.setGameName(query_column_for_string(result, 0));
+                game.setRating(query_column_for_double(result, 1));
+                game.setStartTime(query_column_for_int(result, 2));
+                game.setEndTime(query_column_for_int(result, 2));
+                game.setHighScore(query_column_for_int(result, 3));
             }
-            return row;
+        } else {
+            std::cout << "Query failed" << std::endl;
         }
+        free_all_query_results();
+        free_database(dataBase);
+        return game;
+    }
 
-        //get the stats for a specific game
-        // Average rating of a game
-        // Total time played of a game in seconds (stored in both start and end time)
-        // Max high score of a of game
-        GameData getStats(Database *db, string gameName)
-        {
-            GameData game = GameData();
-            database dataBase;
-            query_result result = db->queryDatabase(dataBase, "SELECT gameName, AVG(rating) AS averageRating, SUM(endTime-startTime) AS totalPlaytime, MAX(highScore) as highscore FROM gameData WHERE gameName='" + gameName + "';");
-            if (query_success(result))
-            {
-                std::cout << "Query success" << std::endl;
-                if (has_row(result))
-                {
-                    if (query_type_of_col(result, 0) == "NULL")
-                    {
-                        std::cout << "No data returned from query!" << std::endl;
-                        return game;
-                    }
+    // get all the game stats
+    //  Average rating of a vector of games
+    //  Total time played of a vector of games in seconds (stored in both start and end time)
+    //  Max high score of a vector of games
+    std::vector<GameData> getAllStats(Database *db)
+    {
+        std::vector<GameData> stats;
+        GameData game = GameData();
+        database dataBase;
+        query_result result =
+            db->queryDatabase(dataBase, "SELECT gameName, AVG(rating) AS averageRating, SUM(endTime-startTime) AS "
+                                        "totalPlaytime, MAX(highScore) as highscore FROM gameData GROUP BY gameName;");
+        if (query_success(result)) {
+            if (has_row(result)) {
+                if (query_type_of_col(result, 0) == "NULL") {
+                    std::cout << "No data returned from query!" << std::endl;
+                    return stats;
+                }
+                do {
                     game.setGameName(query_column_for_string(result, 0));
                     game.setRating(query_column_for_double(result, 1));
                     game.setStartTime(query_column_for_int(result, 2));
-                    game.setEndTime(query_column_for_int(result,2));
-                    game.setHighScore(query_column_for_int(result,3));
-                }
+                    game.setEndTime(query_column_for_int(result, 2));
+                    game.setHighScore(query_column_for_int(result, 3));
+                    stats.push_back(game);
+                } while (get_next_row(result));
             }
-            else {
-                std::cout << "Query failed" << std::endl;
-            }
-            free_all_query_results();
-            free_database(dataBase);
-            return game;
+        } else {
+            std::cout << "Query failed" << std::endl;
         }
+        free_all_query_results();
+        free_database(dataBase);
+        return stats;
+    }
 
-        //get all the game stats
-        // Average rating of a vector of games
-        // Total time played of a vector of games in seconds (stored in both start and end time)
-        // Max high score of a vector of games
-        std::vector<GameData> getAllStats(Database *db) { 
-            std::vector<GameData> stats;
-            GameData game = GameData();
-            database dataBase;
-            query_result result = db->queryDatabase(dataBase, "SELECT gameName, AVG(rating) AS averageRating, SUM(endTime-startTime) AS totalPlaytime, MAX(highScore) as highscore FROM gameData GROUP BY gameName;");
-            if (query_success(result))
-            {
-                if (has_row(result))
-                {
-                    if (query_type_of_col(result, 0) == "NULL")
-                    {
-                        std::cout << "No data returned from query!" << std::endl;
-                        return stats;
-                    }
-                    do {
-                        game.setGameName(query_column_for_string(result, 0));
-                        game.setRating(query_column_for_double(result, 1));
-                        game.setStartTime(query_column_for_int(result, 2));
-                        game.setEndTime(query_column_for_int(result,2));
-                        game.setHighScore(query_column_for_int(result,3));
-                        stats.push_back(game);
-                    } while(get_next_row(result));
-                }
-            }
-            else {
-                std::cout << "Query failed" << std::endl;
-            }
-            free_all_query_results();
-            free_database(dataBase);
-            return stats;
+    // Print all game data
+    void printAllStats(std::map<std::string, GameData> data)
+    {
+        for (auto const &x : data) {
+            GameData game = x.second;
+            std::cout << "==== Game Data ====" << std::endl;
+            std::cout << "Game Name: " << x.first << std::endl;
+            std::cout << "Start Time: " << game.getStartTime() << std::endl;
+            std::cout << "End Time: " << game.getEndTime() << std::endl;
+            std::cout << "Rating: " << game.getRating() << std::endl;
+            std::cout << "High Score: " << game.getHighScore() << std::endl;
+            std::cout << "==================" << std::endl;
         }
-
-        // Print all game data
-        void printAllStats(std::map<std::string, GameData> data) {
-            for (auto const& x : data) {
-                GameData game = x.second;
-                std::cout << "==== Game Data ====" << std::endl;
-                std::cout << "Game Name: " << x.first << std::endl;
-                std::cout << "Start Time: " << game.getStartTime() << std::endl;
-                std::cout << "End Time: " << game.getEndTime() << std::endl;
-                std::cout << "Rating: " << game.getRating() << std::endl;
-                std::cout << "High Score: " << game.getHighScore() << std::endl;
-                std::cout << "==================" << std::endl;
-            }
-        }
+    }
 };
 #endif

--- a/include/GameScreenButton.h
+++ b/include/GameScreenButton.h
@@ -1,14 +1,14 @@
 #ifndef ARCADE_MACHINE_GAME_SCREEN_BUTTON_H
 #define ARCADE_MACHINE_GAME_SCREEN_BUTTON_H
 
-#include <string>
 #include "Button.h"
+#include <string>
 
 /**
-* @brief Buttons created for Game Screen Menu
-* 
-* Derived from abstract Button class
-*/
+ * @brief Buttons created for Game Screen Menu
+ *
+ * Derived from abstract Button class
+ */
 class GameScreenButton : public Button
 {
 public:
@@ -16,9 +16,8 @@ public:
     GameScreenButton(Color c, std::string s, float scale = 1);
 
     void btnImage(std::string image) override;
-    void drawButton() override; 
+    void drawButton() override;
     std::string action(std::string keyinput = "") override;
-
 };
 
 #endif

--- a/include/GridLayout.h
+++ b/include/GridLayout.h
@@ -1,10 +1,10 @@
 #ifndef ARCADE_MACHINE_GRID_LAYOUT_H
 #define ARCADE_MACHINE_GRID_LAYOUT_H
 
-#include <string>
-#include "splashkit.h"
 #include "Button.h"
 #include "Cell.h"
+#include "splashkit.h"
+#include <string>
 
 class GridLayout
 {
@@ -12,7 +12,7 @@ private:
     // Stores the bitmap used for the background
     bitmap m_background = nullptr;
     // Stores the number of columns per row
-    int* m_colsArray;
+    int *m_colsArray;
     // Different number of columns per row?
     bool _useColsArray = false;
     // Columns, used if number of columns is fixed
@@ -20,7 +20,7 @@ private:
     // Rows
     int _rows;
     // Stores information for each cell (bitmap, span)
-    Cell* _grid;
+    Cell *_grid;
     // Number of cells
     int _cells = 0;
     // Scale the bitmap to fill the cell
@@ -29,7 +29,9 @@ private:
     bool _gridEmpty = true;
 
 public:
-    GridLayout() {}
+    GridLayout()
+    {
+    }
     GridLayout(int rows, int cols, bool scaleToFit = false);
     GridLayout(int rows, int colsArray[], bool scaleToFit = false);
 
@@ -41,14 +43,14 @@ public:
 
     void drawCells();
     void drawGrid();
-    
+
     int findCell(int row, int col);
     Cell getCell(int row, int col);
-    
+
     void updateCell(const bitmap &bmp, int row, int col, int span = 1, bool centre = true);
     void updateCell(const sprite &sprite, int row, int col, int span = 1, bool centre = true);
     void updateCell(Button *button, int row, int col, int span = 1, bool centre = true);
-    
+
     void updateAllCells(bitmap bmp, bool centre = true);
     void updateAllCells(sprite sprite, bool centre = true);
 
@@ -56,7 +58,6 @@ public:
     void clearGrid();
     point_2d findCellFromLoc(int x, int y);
     void clearCell(int row, int col);
-
 };
 
 #endif

--- a/include/Helper.h
+++ b/include/Helper.h
@@ -17,182 +17,170 @@ namespace fs = std::experimental::filesystem;
 
 /**
  * @brief Helper class
- * This class has been added to house orphan functions 
- * 
+ * This class has been added to house orphan functions
+ *
  */
-class Helper {
-    public:
+class Helper
+{
+public:
+    /**
+     * @brief Find the game folder name to store in config class.
+     *
+     * @param entryPath
+     * @return * string
+     */
+    string getFolderName(string entryPath)
+    {
+        string dir = fs::path(entryPath).remove_filename().generic_string();
+        std::cout << "Game-Directory Path: " << dir << "\n";
+        return dir;
+    }
 
-        /**
-         * @brief Find the game folder name to store in config class.
-         * 
-         * @param entryPath 
-         * @return * string 
-         */
-        string getFolderName(string entryPath)
-        {
-            string dir  = fs::path(entryPath).remove_filename().generic_string();
-            std::cout << "Game-Directory Path: " << dir << "\n";
-            return dir;
-        }
+    /**
+     * @brief Find the config files in the games directory.
+     *
+     * @param dir The games directory
+     * @return * vector<string>
+     */
+    vector<string> getConfigFiles(string dir)
+    {
+        vector<string> files;
 
-        /**
-         * @brief Find the config files in the games directory.
-         * 
-         * @param dir The games directory
-         * @return * vector<string> 
-         */
-        vector<string> getConfigFiles(string dir)
-        {
-            vector<string> files;
-
-            for (const auto & entry : fs::recursive_directory_iterator(dir))
-            {
-                if (entry.path().filename() == "config.txt")
-                {
-                    std::cout << "Game-Config Path: " << entry.path().generic_string() << "\n";
-                    files.push_back(entry.path().generic_string());
-                }
+        for (const auto &entry : fs::recursive_directory_iterator(dir)) {
+            if (entry.path().filename() == "config.txt") {
+                std::cout << "Game-Config Path: " << entry.path().generic_string() << "\n";
+                files.push_back(entry.path().generic_string());
             }
-
-            return files;
         }
 
-        /**
-         * @brief Create configs vector from config files
-         * 
-         * @return * vector<ConfigData> 
-         */
-        vector<ConfigData> ConfigDataList()
-        {   
-            vector<string> files = getConfigFiles("./games/games");
+        return files;
+    }
 
-            vector<ConfigData> configs;
+    /**
+     * @brief Create configs vector from config files
+     *
+     * @return * vector<ConfigData>
+     */
+    vector<ConfigData> ConfigDataList()
+    {
+        vector<string> files = getConfigFiles("./games/games");
 
-            for (int i = 0; i < files.size(); i++)
-            {
-                #ifdef ARCADE_MACHINE_USE_TEXT_CONFIG 
-                    ConfigData config(files[i]);
-                    string dir = getFolderName(files[i]);
-                    config.setFolder(dir);
-                    config.setId(i);
-                    config.printConfigData();
-                    configs.push_back(config);
-                #else
-                    ConfigData config;
-                    string filename = fs::path(files[i]).string();
-                    write_line(filename);
-                    config.collectJsonData(config.readJson(filename));
-                    config.setId(i);
-                    config.printConfigData();
-                    configs.push_back(config);
-                #endif
+        vector<ConfigData> configs;
+
+        for (int i = 0; i < files.size(); i++) {
+#ifdef ARCADE_MACHINE_USE_TEXT_CONFIG
+            ConfigData config(files[i]);
+            string dir = getFolderName(files[i]);
+            config.setFolder(dir);
+            config.setId(i);
+            config.printConfigData();
+            configs.push_back(config);
+#else
+            ConfigData config;
+            string filename = fs::path(files[i]).string();
+            write_line(filename);
+            config.collectJsonData(config.readJson(filename));
+            config.setId(i);
+            config.printConfigData();
+            configs.push_back(config);
+#endif
+        }
+
+        return configs;
+    }
+
+    /**
+     * @brief To be used in conjuntion with GridLayoutExample
+     *
+     * @param grid
+     */
+    void resetScreen(GridLayout grid)
+    {
+        process_events();
+        clear_screen(COLOR_DARK_SLATE_GRAY);
+        grid.drawGrid();
+        grid.clearGrid();
+        refresh_screen();
+        delay(1000);
+    }
+
+    /**
+     * @brief To test the grid layout
+     *
+     */
+    void gridLayoutExample()
+    {
+        bitmap testBitmap = load_bitmap("test", "appContainer.png");
+        open_window("Grid Layout Example", 600, 800);
+
+        // int colsArray[5] = {4, 2, 3, 2, 2};
+        int rows = 5;
+        int cols = 5;
+        //#rows, #cols, ScaletoFit
+        GridLayout grid(rows, cols, true);
+        // Grid grid(rows,colsArray, true);
+
+        resetScreen(grid);
+
+        int span = cols;
+        for (size_t i = 0; i < rows; i++) {
+            grid.updateCell(testBitmap, i, 0, span);
+            --span;
+        }
+        resetScreen(grid);
+
+        span = 1;
+        for (size_t i = 0; i < rows; i++) {
+            grid.updateCell(testBitmap, i, 0, span);
+            ++span;
+        }
+
+        resetScreen(grid);
+
+        bool alternate = true;
+        for (size_t i = 0; i < rows; i++) {
+            for (size_t j = 0; j < cols; j++) {
+                if (alternate)
+                    grid.updateCell(testBitmap, i, j, 1);
+                alternate = !alternate;
             }
-
-            return configs;
         }
-        
-        /**
-         * @brief To be used in conjuntion with GridLayoutExample
-         * 
-         * @param grid 
-         */
-        void resetScreen(GridLayout grid)
-        {
-            process_events();
-            clear_screen(COLOR_DARK_SLATE_GRAY);
+
+        resetScreen(grid);
+
+        alternate = false;
+        for (size_t i = 0; i < rows; i++) {
+            for (size_t j = 0; j < cols; j++) {
+                if (alternate)
+                    grid.updateCell(testBitmap, i, j, 1);
+            }
+            alternate = !alternate;
+        }
+
+        resetScreen(grid);
+
+        alternate = false;
+        for (size_t i = 0; i < cols; i++) {
+            for (size_t j = 0; j < rows; j++) {
+                if (alternate)
+                    grid.updateCell(testBitmap, i, j, 1);
+                alternate = !alternate;
+            }
+            alternate = !alternate;
+        }
+
+        resetScreen(grid);
+
+        grid.updateAllCells(testBitmap);
+        resetScreen(grid);
+
+        while (!quit_requested()) {
             grid.drawGrid();
-            grid.clearGrid();
-            refresh_screen();
-            delay(1000);
+            process_events();
+            clear_screen();
+            refresh_screen(60);
         }
-        
-        /**
-         * @brief To test the grid layout 
-         * 
-         */
-        void gridLayoutExample()
-        {
-            bitmap testBitmap = load_bitmap("test", "appContainer.png");
-            open_window("Grid Layout Example", 600, 800);
-
-            //int colsArray[5] = {4, 2, 3, 2, 2};
-            int rows = 5;
-            int cols = 5;
-            //#rows, #cols, ScaletoFit
-            GridLayout grid(rows, cols, true);
-            //Grid grid(rows,colsArray, true);
-
-            resetScreen(grid);
-
-            int span = cols;
-            for (size_t i = 0; i < rows; i++)
-            {
-                grid.updateCell(testBitmap, i, 0, span);
-                --span;
-            }
-            resetScreen(grid);
-
-            span = 1;
-            for (size_t i = 0; i < rows; i++)
-            {
-                grid.updateCell(testBitmap, i, 0, span);
-                ++span;
-            }
-
-            resetScreen(grid);
-
-            bool alternate = true;
-            for (size_t i = 0; i < rows; i++)
-            {
-                for (size_t j = 0; j < cols; j++)
-                {
-                    if (alternate)
-                        grid.updateCell(testBitmap, i, j, 1);
-                    alternate = !alternate;
-                }
-            }
-
-            resetScreen(grid);
-
-            alternate = false;
-            for (size_t i = 0; i < rows; i++)
-            {
-                for (size_t j = 0; j < cols; j++)
-                {
-                    if (alternate)
-                        grid.updateCell(testBitmap, i, j, 1);
-                }
-                alternate = !alternate;
-            }
-
-            resetScreen(grid);
-
-            alternate = false;
-            for (size_t i = 0; i < cols; i++)
-            {
-                for (size_t j = 0; j < rows; j++)
-                {
-                    if (alternate)
-                        grid.updateCell(testBitmap, i, j, 1);
-                    alternate = !alternate;
-                }
-                alternate = !alternate;
-            }
-
-            resetScreen(grid);
-
-            grid.updateAllCells(testBitmap);
-            resetScreen(grid);
-
-            while (!quit_requested())
-            {
-                grid.drawGrid();
-                process_events();
-                clear_screen();
-                refresh_screen(60);
-            }
-        }
+    }
 };
 
 #endif

--- a/include/Menu.h
+++ b/include/Menu.h
@@ -1,24 +1,24 @@
 #ifndef ARCADE_MACHINE_MENU_H
 #define ARCADE_MACHINE_MENU_H
 
-#include "Tip.h"
-#include "Selector.h"
-#include "GameData.h"
-#include "Database.h"
-#include "Rating.h"
-#include "Table.h"
-#include "GridLayout.h"
 #include "Button.h"
-#include "MenuButton.h"
+#include "Database.h"
+#include "GameData.h"
 #include "GameScreenButton.h"
+#include "GridLayout.h"
+#include "MenuButton.h"
+#include "Rating.h"
+#include "Selector.h"
+#include "Table.h"
+#include "Tip.h"
 
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
+#include <chrono>
 #include <string>
 #include <vector>
-#include <chrono>
 
 // --------- borrowed from ArcadeMachine.h .... bad fix tho
 #define ARCADE_MACHINE_SCALING_FACTOR 1
@@ -26,7 +26,8 @@
 #define ARCADE_MACHINE_RES_Y 1080 * ARCADE_MACHINE_SCALING_FACTOR
 // --------------------------------------------------------
 
-class Menu {
+class Menu
+{
 private:
     std::string m_background = "games_dashboard";
     // Vector to store the config data of each game
@@ -63,7 +64,7 @@ private:
     // Checks if program has exited
     bool m_programExit;
     // Vector of buttons
-    std::vector<Button*> m_btns;
+    std::vector<Button *> m_btns;
     // Vector to store game images
     std::vector<std::string> m_gameImages;
     // Menu grid
@@ -106,31 +107,37 @@ public:
     ~Menu();
 
     // Getters
-    auto getButtons() const -> const std::vector<Button*> { return this->m_btns; }
-    bool getOverlayState() { return m_overlayActive; }
+    auto getButtons() const -> const std::vector<Button *>
+    {
+        return this->m_btns;
+    }
+    bool getOverlayState()
+    {
+        return m_overlayActive;
+    }
 
-    std::vector<std::string> getGameSprites(std::vector<ConfigData> configs); // gets game images from the config files and returns vector
+    std::vector<std::string> getGameSprites(
+        std::vector<ConfigData> configs); // gets game images from the config files and returns vector
 
-    void createGrid(); // Create a GridLayout object
+    void createGrid();    // Create a GridLayout object
     void createButtons(); // Create a list of games
-    void createTip(); // create a tip to display to the user.
+    void createTip();     // create a tip to display to the user.
     void updateCarousel();
     void carouselHandler();
     void drawMenuPage();
     void updateSlide(sprite buttonSprite, int position); // Method to update the sprite positions and draw sprite.
-    void drawUpdateSlideLeft(); // Slide the game buttons on left key input.
-    void drawUpdateSlideRight(); // Slide the game buttons on right key input.
+    void drawUpdateSlideLeft();                          // Slide the game buttons on left key input.
+    void drawUpdateSlideRight();                         // Slide the game buttons on right key input.
     void drawOverlay(ConfigData config, GameData stats); // Draw an overlay over the game, using data from the config.
 
 #ifdef _WIN32
     bool focusWindow(std::string windowName, int timeout = 2000);
-    void startGame(LPCSTR gamePath,LPSTR gameExe, LPCSTR gameDirectory);
+    void startGame(LPCSTR gamePath, LPSTR gameExe, LPCSTR gameDirectory);
     void checkGameExit();
 #endif
 
     void backToGamesMenu(); // Fade back to games menu
     void fade(double alphaStart, double alphaEnd, double alphaStep);
-
 };
 
 #endif

--- a/include/MenuButton.h
+++ b/include/MenuButton.h
@@ -1,25 +1,28 @@
 #ifndef ARCADE_MACHINE_MENU_BUTTON_H
 #define ARCADE_MACHINE_MENU_BUTTON_H
 
-#include <string>
 #include "Button.h"
+#include <string>
 
 /**
-* @brief Buttons created for the main opening Menu Screen
-* 
-* Derived from abstract Button class
-*/
+ * @brief Buttons created for the main opening Menu Screen
+ *
+ * Derived from abstract Button class
+ */
 class MenuButton : public Button
 {
 public:
     MenuButton(Color c, float scale = 1);
 
-    void getButtonImage(std::string image) {} //?
+    void getButtonImage(std::string image)
+    {
+    } //?
 
-    void btnImage(std::string image) override {}
-    void drawButton() override; 
+    void btnImage(std::string image) override
+    {
+    }
+    void drawButton() override;
     std::string action(std::string keyinput = "") override;
-
 };
 
 #endif

--- a/include/Option.h
+++ b/include/Option.h
@@ -1,19 +1,19 @@
 #ifndef ARCADE_MACHINE_OPTION_H
 #define ARCADE_MACHINE_OPTION_H
 
+#include "ArcadeMachine.h"
+#include "Audio.h"
+#include "Button.h"
+#include "GridLayout.h"
+#include "OptionsScreenButton.h"
+#include "Selector.h"
 #include "splashkit.h"
 #include <string>
-#include "GridLayout.h"
-#include "Button.h"
-#include "ArcadeMachine.h"
-#include "Selector.h"
-#include "OptionsScreenButton.h"
-#include "Audio.h"
 
 // Options class
 class Option
 {
-private: 
+private:
     int m_displayStyle = 1;
     int _selector = 1;
     bool m_isSelected = false;
@@ -24,11 +24,11 @@ private:
 
     GridLayout m_grid;
     Audio m_audio;
-    std::vector<Button*> m_optionsBtns;
+    std::vector<Button *> m_optionsBtns;
     ButtonNode *m_optionsButtonNode = nullptr;
     Selector m_selectorOptionsMenu;
     point_2d m_mouse;
-    std::string m_action; 
+    std::string m_action;
 
 public:
     Option();
@@ -37,7 +37,6 @@ public:
     void drawOptionsMenu();
     bool checkAction();
     void soundMenu();
-
 
     float getVolume();
     int getCurrentMusic();

--- a/include/OptionsScreenButton.h
+++ b/include/OptionsScreenButton.h
@@ -1,23 +1,22 @@
 #ifndef ARCADE_MACHINE_OPTIONS_SCREEN_BUTTON_H
 #define ARCADE_MACHINE_OPTIONS_SCREEN_BUTTON_H
 
-#include <string>
 #include "Button.h"
+#include <string>
 
 /**
-* @brief Buttons created for Options Screen Menu
-* 
-* Derived from abstract Button class
-*/
+ * @brief Buttons created for Options Screen Menu
+ *
+ * Derived from abstract Button class
+ */
 class OptionsScreenButton : public Button
 {
 public:
     OptionsScreenButton(Color c, float scale = 1);
 
     void btnImage(std::string image) override;
-    void drawButton() override; 
+    void drawButton() override;
     std::string action(std::string keyinput = "") override;
-
 };
 
 #endif

--- a/include/Rating.h
+++ b/include/Rating.h
@@ -22,47 +22,44 @@ public:
 
         updateGrid();
     }
-    ~Rating() {}
+    ~Rating()
+    {
+    }
 
-    //Draw the rating page
+    // Draw the rating page
     void draw()
     {
         handleInput();
         _grid.drawGrid();
-        draw_text("Rate your experience",  COLOR_WHITE, "font_title", 100 ,480, 120);  
+        draw_text("Rate your experience", COLOR_WHITE, "font_title", 100, 480, 120);
     }
 
-    //handle input, to be moved to selector?
+    // handle input, to be moved to selector?
     void handleInput()
     {
-        if (key_typed(LEFT_KEY))
-        {
+        if (key_typed(LEFT_KEY)) {
             --_rating;
             if (_rating < 0)
                 _rating = _maxRating;
             updateGrid();
-        }
-        else if (key_typed(RIGHT_KEY))
-        {
+        } else if (key_typed(RIGHT_KEY)) {
             // rating is between 1 and 5
-                ++_rating;
-                _rating = _rating % (_maxRating + 1);
+            ++_rating;
+            _rating = _rating % (_maxRating + 1);
 
             updateGrid();
-        }
-        else if (key_typed(RETURN_KEY))
-        {
+        } else if (key_typed(RETURN_KEY)) {
             _ratingCollected = true;
         }
     }
 
-    int getRating() {
+    int getRating()
+    {
         _rating = 1;
         _ratingCollected = false;
         updateGrid();
         process_events();
-        while (!_ratingCollected)
-        {
+        while (!_ratingCollected) {
             clear_screen();
             draw();
             process_events();
@@ -71,13 +68,12 @@ public:
         return _rating;
     }
 
-    //update the grid, when the rating changes
+    // update the grid, when the rating changes
     void updateGrid()
     {
         {
             _grid.clearGrid();
-            for (int i = 1; i <= _maxRating; i++)
-            {
+            for (int i = 1; i <= _maxRating; i++) {
                 if (i <= _rating)
                     _grid.updateCell(bitmap_named("star-gold"), 1, i);
                 else

--- a/include/Selector.h
+++ b/include/Selector.h
@@ -1,15 +1,16 @@
 #ifndef ARCADE_MACHINE_SELECTOR_H
 #define ARCADE_MACHINE_SELECTOR_H
 
-#include "splashkit.h"
 #include "ButtonNode.h"
+#include "splashkit.h"
 #include <string>
 
-class Selector {
+class Selector
+{
 private:
     /// Checks first button.
     bool m_isFirstButton = true;
-    /// Splashscreen cursor sprite. 
+    /// Splashscreen cursor sprite.
     sprite m_cursorSprite;
     /// Checks if game menu currently sliding left.
     bool m_isSlidingLeft = false;
@@ -21,24 +22,43 @@ private:
     bool m_renderCursor = false;
 
 public:
-    Selector() {}
+    Selector()
+    {
+    }
     Selector(const std::string &cursor);
 
     // Properties used to detect if game menu slide is occurring.
-    auto getSlideLeft() const -> const bool& { return this->m_isSlidingLeft; }
-    auto getSlideRight() const -> const bool& { return this->m_isSlidingRight; }
-    auto setSlideLeft(bool left) { this->m_isSlidingLeft = left; }
-    auto setSlideRight(bool right) { this->m_isSlidingRight = right; }
-    auto setRenderCursor(bool cursor) { this->m_renderCursor = cursor; }
+    auto getSlideLeft() const -> const bool &
+    {
+        return this->m_isSlidingLeft;
+    }
+    auto getSlideRight() const -> const bool &
+    {
+        return this->m_isSlidingRight;
+    }
+    auto setSlideLeft(bool left)
+    {
+        this->m_isSlidingLeft = left;
+    }
+    auto setSlideRight(bool right)
+    {
+        this->m_isSlidingRight = right;
+    }
+    auto setRenderCursor(bool cursor)
+    {
+        this->m_renderCursor = cursor;
+    }
     // Return the cursor sprite
-    sprite getCursor() { return this->m_cursorSprite; }
+    sprite getCursor()
+    {
+        return this->m_cursorSprite;
+    }
 
-    ButtonNode* checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu = false);
-    std::string checkForSelection(ButtonNode* buttonNode, bool isFromGameMenu = false);
-    void highlightFirst(ButtonNode* buttonNode);
-    void highlightButton(ButtonNode* buttonNode, std::string direction);
+    ButtonNode *checkKeyInput(ButtonNode *buttonNode, bool isFromGameMenu = false);
+    std::string checkForSelection(ButtonNode *buttonNode, bool isFromGameMenu = false);
+    void highlightFirst(ButtonNode *buttonNode);
+    void highlightButton(ButtonNode *buttonNode, std::string direction);
     void setNoRenderCursor();
-    
 };
 
 #endif

--- a/include/Splashscreen.h
+++ b/include/Splashscreen.h
@@ -1,8 +1,8 @@
 #ifndef ARCADE_MACHINE_SPLASH_SCREEN_H
 #define ARCADE_MACHINE_SPLASH_SCREEN_H
 
-#include <string>
 #include "splashkit.h"
+#include <string>
 
 class Splashscreen
 {
@@ -11,13 +11,17 @@ private:
 
 public:
     // Default constructor
-    Splashscreen() {}
+    Splashscreen()
+    {
+    }
 
     // Overloaded constructor
-    Splashscreen(std::string bitmap) { this->m_bmp = bitmap; }
+    Splashscreen(std::string bitmap)
+    {
+        this->m_bmp = bitmap;
+    }
 
     void drawTitlePage();
-    
 };
 
 #endif

--- a/include/Table.h
+++ b/include/Table.h
@@ -1,56 +1,65 @@
 #ifndef ARCADE_MACHINE_TABLE_H
 #define ARCADE_MACHINE_TABLE_H
 
+#include "splashkit.h"
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
-#include "splashkit.h"
-#include <map>
 
-class Table {
-    private:
-        std::string m_tableName;
-        std::map<string, string> m_columnNames;
-    public:
-        Table();
-        Table(string tableName){
-            m_tableName = tableName;
-            m_columnNames = std::map<string, string>();
-        };
-        Table(string tableName, std::map<string, string> columnNames){
-            m_tableName = tableName;
-            m_columnNames = columnNames;
-        };
+class Table
+{
+private:
+    std::string m_tableName;
+    std::map<string, string> m_columnNames;
 
-        ~Table()
-        {
-            std::cout << "Destructor called on table: \"" << m_tableName << "\"\n";
-        }
+public:
+    Table();
+    Table(string tableName)
+    {
+        m_tableName = tableName;
+        m_columnNames = std::map<string, string>();
+    };
+    Table(string tableName, std::map<string, string> columnNames)
+    {
+        m_tableName = tableName;
+        m_columnNames = columnNames;
+    };
 
-        // Setters
-        void setTableName(string tableName){
-            m_tableName = tableName;
-        };
-        void setColumnNames(std::map<string, string> columnNames){
-            m_columnNames = columnNames;
-        };
+    ~Table()
+    {
+        std::cout << "Destructor called on table: \"" << m_tableName << "\"\n";
+    }
 
-        // Getters
-        string getTableName(){
-            return m_tableName;
-        };
-        std::map<string, string> getColumnNames(){
-            return m_columnNames;
-        };
+    // Setters
+    void setTableName(string tableName)
+    {
+        m_tableName = tableName;
+    };
+    void setColumnNames(std::map<string, string> columnNames)
+    {
+        m_columnNames = columnNames;
+    };
 
-        // Methods
-        void addColumn(string columnName, string columnType){
-            m_columnNames.insert({columnName, columnType});
-        };
-        void removeColumn(string columnName){
-            m_columnNames.erase(columnName);
-        };
+    // Getters
+    string getTableName()
+    {
+        return m_tableName;
+    };
+    std::map<string, string> getColumnNames()
+    {
+        return m_columnNames;
+    };
 
+    // Methods
+    void addColumn(string columnName, string columnType)
+    {
+        m_columnNames.insert({columnName, columnType});
+    };
+    void removeColumn(string columnName)
+    {
+        m_columnNames.erase(columnName);
+    };
 };
 
 #endif

--- a/include/Tip.h
+++ b/include/Tip.h
@@ -16,8 +16,7 @@
 #define WBORDER_OFFSET 20
 
 // Possible locations of the container
-enum location
-{
+enum location {
     TOPLEFT,
     TOPRIGHT,
     TOPCENTER,
@@ -30,32 +29,32 @@ class Tip
 {
 private:
     bitmap m_image;
-    //bitmap dimensions
+    // bitmap dimensions
     int m_bmpWidth;
     int m_bmpHeight;
     string m_text;
-    //Length of the string, text
+    // Length of the string, text
     int m_textLength;
-    //Number of characters per line
+    // Number of characters per line
     int m_charsPerLine = 0;
-    //Number of lines
+    // Number of lines
     int m_numLines;
-    //Location within the window where the container lies
+    // Location within the window where the container lies
     location m_loc;
-    //Where the container will be anchored within the screen.
+    // Where the container will be anchored within the screen.
     int m_xOffset;
     int m_yOffset;
     std::chrono::time_point<std::chrono::steady_clock> m_startTime;
     int m_duration;
 
-    //Height of the container
+    // Height of the container
     int m_containerHeight;
-    //Width of the container
+    // Width of the container
     int m_containerWidth;
 
-    //Stores the animation
+    // Stores the animation
     animation m_anim = nullptr;
-    //Drawing options required to load the animation
+    // Drawing options required to load the animation
     drawing_options m_opt = option_defaults();
 
     int m_i = 30;
@@ -63,14 +62,16 @@ private:
     void calculatePosition();
 
 public:
-    Tip() {}
+    Tip()
+    {
+    }
     Tip(string text, bitmap image, int duration = 3000, int charsPerLine = 30, location loc = TOPCENTER);
-    Tip(string text, bitmap image, animation anim, drawing_options opt, int duration = 3000, int charsPerLine = 30, location loc = TOPCENTER);
+    Tip(string text, bitmap image, animation anim, drawing_options opt, int duration = 3000, int charsPerLine = 30,
+        location loc = TOPCENTER);
 
     ~Tip();
 
     void draw();
-
 };
 
 #endif

--- a/src/ArcadeMachine.cpp
+++ b/src/ArcadeMachine.cpp
@@ -1,23 +1,19 @@
 #include "ArcadeMachine.h"
 
-#include <iostream>
-#include <cstdlib>
 #include <cmath>
+#include <cstdlib>
+#include <iostream>
 
 // Helper function to load developer names into m_arcadeTeamDeveloperNames
 // Called in the constructor
-void ArcadeMachine::loadDeveloperNames(const char* filePath)
+void ArcadeMachine::loadDeveloperNames(const char *filePath)
 {
     std::string line;
     std::ifstream developerNamesFile(filePath);
-    if (developerNamesFile.fail())
-    {
+    if (developerNamesFile.fail()) {
         std::cout << "error: unable to open developer names file\n";
-    }
-    else if (developerNamesFile.is_open())
-    {
-        while(std::getline(developerNamesFile, line))
-        {
+    } else if (developerNamesFile.is_open()) {
+        while (std::getline(developerNamesFile, line)) {
             m_arcadeTeamDeveloperNames.push_back(line);
         }
     }
@@ -36,10 +32,10 @@ ArcadeMachine::ArcadeMachine()
 
     // load developer names into m_arcadeTeamDeveloperNames
     loadDeveloperNames("developer_names.txt");
-    
+
     Splashscreen introArcadeMachineTeam("intro_arcade_team");
     Splashscreen introSplashkit("intro_splashkit");
-    
+
     // Set objects to private properties
     this->m_helper = helper;
     this->m_config = config;
@@ -53,9 +49,11 @@ ArcadeMachine::~ArcadeMachine()
 {
     std::cout << "Destructor called on ArcadeMachine\n";
     std::cout << "ArcadeMachine: clearing memory...\n";
-    for (const auto& button : m_menuBtns) delete button;
+    for (const auto &button : m_menuBtns)
+        delete button;
     m_menuBtns.clear();
-    for (const auto& button : m_gameBtns) delete button;
+    for (const auto &button : m_gameBtns)
+        delete button;
     m_gameBtns.clear();
     m_grid.destroy();
 }
@@ -65,8 +63,7 @@ ArcadeMachine::~ArcadeMachine()
 */
 void ArcadeMachine::mainMenu()
 {
-    while (!quit_requested())
-    {
+    while (!quit_requested()) {
         process_events();
         clear_screen();
         drawMainMenu();
@@ -90,12 +87,11 @@ void ArcadeMachine::gamesMenu()
     write_line("got buttons");
     write_line("set image");
     this->m_gameBtns = menu.getButtons();
-    
-    while ((!key_typed(ESCAPE_KEY) && !overlayActive) || overlayActive)
-    {
-        //write_line("into while");
+
+    while ((!key_typed(ESCAPE_KEY) && !overlayActive) || overlayActive) {
+        // write_line("into while");
         overlayActive = menu.getOverlayState();
-        process_events();   
+        process_events();
         clear_screen();
         // Get mouse position
         this->m_mouse = mouse_position();
@@ -115,31 +111,27 @@ void ArcadeMachine::optionsMenu()
     Option options;
     bool has_background_music = false;
     options.createOptionsButtons();
-    
-    while (this->m_exitOptions == false)
-    {
+
+    while (this->m_exitOptions == false) {
         process_events();
         clear_screen();
 
-        //options.updateOption();
+        // options.updateOption();
         options.drawOptionsMenu();
 
         this->m_exitOptions = options.checkAction();
-        
-        if(!has_background_music)
-        {
-            //audio->playMusic(options.getCurrentMusic(), options.getVolume());
-            has_background_music=false;   
-        }
-        
-        if(options.isChangeMusic())
-        {
-            has_background_music=false;
+
+        if (!has_background_music) {
+            // audio->playMusic(options.getCurrentMusic(), options.getVolume());
+            has_background_music = false;
         }
 
-        if(options.isChangeVoLume())
-        {
-            //audio->setVolume(options.getVolume());
+        if (options.isChangeMusic()) {
+            has_background_music = false;
+        }
+
+        if (options.isChangeVoLume()) {
+            // audio->setVolume(options.getVolume());
         }
 
         refresh_screen(60);
@@ -147,7 +139,7 @@ void ArcadeMachine::optionsMenu()
 
     this->m_exitOptions = false;
 
-    //fade_music_out(500);
+    // fade_music_out(500);
 }
 
 /**
@@ -158,22 +150,20 @@ void ArcadeMachine::optionsMenu()
 void ArcadeMachine::buttonClicked(point_2d point)
 {
     // Play
-    if ( this->m_action == "play" || (sprite_at(this->m_menuBtns[0]->btn(), point) && mouse_clicked(LEFT_BUTTON)) )
-    {
+    if (this->m_action == "play" || (sprite_at(this->m_menuBtns[0]->btn(), point) && mouse_clicked(LEFT_BUTTON))) {
         gamesMenu();
         write_line("Play button clicked");
     }
 
     // Options
-    else if ( this->m_action == "options" || (sprite_at(this->m_menuBtns[1]->btn(), point) && mouse_clicked(LEFT_BUTTON)) )
-    {
+    else if (this->m_action == "options" ||
+             (sprite_at(this->m_menuBtns[1]->btn(), point) && mouse_clicked(LEFT_BUTTON))) {
         optionsMenu();
         write_line("Options button clicked");
     }
 
     // Exit
-    else if ( this->m_action == "exit" || (sprite_at(this->m_menuBtns[2]->btn(), point) && mouse_clicked(LEFT_BUTTON)) )
-    {
+    else if (this->m_action == "exit" || (sprite_at(this->m_menuBtns[2]->btn(), point) && mouse_clicked(LEFT_BUTTON))) {
         write_line("Exit button clicked");
         exitProgram();
     }
@@ -182,7 +172,7 @@ void ArcadeMachine::buttonClicked(point_2d point)
 /**
     Draws the Main Menu
 */
-void ArcadeMachine::drawMainMenu() 
+void ArcadeMachine::drawMainMenu()
 {
     // Get mouse position
     this->m_mouse = mouse_position();
@@ -195,12 +185,15 @@ void ArcadeMachine::drawMainMenu()
     Cell options = this->m_grid.getCell(3, 10);
     Cell exit = this->m_grid.getCell(4, 10);
     // Arcade Machine title
-    draw_text("Arcade",  COLOR_BLACK, "font_title", 100, 1180, 100);
+    draw_text("Arcade", COLOR_BLACK, "font_title", 100, 1180, 100);
     draw_text("Machine", COLOR_BLACK, "font_title", 100, 1150, 200);
     // Draw text on buttons
-    draw_text("play!", COLOR_BLACK, "font_btn", 70, play.button->x() + (play.button->centreX()/2) + 5, play.button->y() + 5);
-    draw_text("options", COLOR_BLACK, "font_btn", 70, options.button->x() + (options.button->centreX()/2) - 20, options.button->y() + 5);
-    draw_text("exit", COLOR_BLACK, "font_btn", 70, exit.button->x() + (exit.button->centreX()/2) + 20, exit.button->y() + 5);
+    draw_text("play!", COLOR_BLACK, "font_btn", 70, play.button->x() + (play.button->centreX() / 2) + 5,
+              play.button->y() + 5);
+    draw_text("options", COLOR_BLACK, "font_btn", 70, options.button->x() + (options.button->centreX() / 2) - 20,
+              options.button->y() + 5);
+    draw_text("exit", COLOR_BLACK, "font_btn", 70, exit.button->x() + (exit.button->centreX() / 2) + 20,
+              exit.button->y() + 5);
 
     // Check input in selector class.
     this->m_menuButtonNode = this->m_selectorMainMenu.checkKeyInput(this->m_menuButtonNode);
@@ -216,8 +209,8 @@ void ArcadeMachine::prepareMainMenu()
 {
     // Get the data from the config files.
     this->m_configs = this->m_helper.ConfigDataList();
-    
-    // Initialise grid 
+
+    // Initialise grid
     GridLayout grid(ROWS, COLS);
     this->m_grid = grid;
 
@@ -233,7 +226,7 @@ void ArcadeMachine::prepareMainMenu()
 
     // Fetch menu background
     bitmap thoth = bitmap_named("thoth");
-    
+
     // Update grid cells with assets
     this->m_grid.setBackground(thoth);
 
@@ -248,7 +241,8 @@ void ArcadeMachine::prepareMainMenu()
     this->m_grid.updateCell(m_menuButtonNode->getNext()->button, 3, 10);
 
     // Play main menu music
-    if (this->m_playMusic) play_music("music_mainmenu");
+    if (this->m_playMusic)
+        play_music("music_mainmenu");
 }
 
 /// Plays the Thoth Tech splashscreen animation
@@ -258,25 +252,24 @@ void ArcadeMachine::playThothTechIntro()
     double alpha = 1.0;
     // Set iterations
     int i = 60;
-    // Play Thoth Tech Company sound 
+    // Play Thoth Tech Company sound
     play_sound_effect("intro_thoth");
 
-    while(i != 0)
-    {
+    while (i != 0) {
         process_events();
         clear_screen();
         // Draw logo
         m_introThothTech.drawTitlePage();
         // Fill screen with white at alpha value (opacity)
         fill_rectangle(rgba_color(1.0, 1.0, 1.0, alpha), 0, 0, ARCADE_MACHINE_RES_X, ARCADE_MACHINE_RES_Y);
-        // Decrement i and alpha 
-        i--; alpha = alpha - 0.05;
+        // Decrement i and alpha
+        i--;
+        alpha = alpha - 0.05;
         // If alpha is == 0, hold image for 1.5 seconds
-        if (std::abs(alpha - 0.0) < 1e-9)
-        {
+        if (std::abs(alpha - 0.0) < 1e-9) {
             delay(2000);
             /*  After this has happened, the alpha value will continue into the negatives
-                The colour function continues to accept negative alpha values, 
+                The colour function continues to accept negative alpha values,
                 effectively creating a fade out animation for the remainder of the while loop
             */
         }
@@ -292,11 +285,10 @@ void ArcadeMachine::playArcadeTeamIntro()
     double alpha = 1.0;
     // Set iterations
     int i = 60;
-    // Play Thoth Tech Company sound 
+    // Play Thoth Tech Company sound
     play_sound_effect("intro_coin");
 
-    while(i != 0)
-    {
+    while (i != 0) {
         process_events();
         clear_screen();
 
@@ -305,28 +297,23 @@ void ArcadeMachine::playArcadeTeamIntro()
 
         int developerNameSpacing = 32;
         int developerNameIndex = 0;
-        for  (const auto& developerName : m_arcadeTeamDeveloperNames)
-        {
-            draw_text(developerName,
-                COLOR_BLACK,
-                "font_text",
-                26,
-                (ARCADE_MACHINE_RES_X / 2) - 180,
-                (ARCADE_MACHINE_RES_Y / 2) + 220 + developerNameSpacing * developerNameIndex);
+        for (const auto &developerName : m_arcadeTeamDeveloperNames) {
+            draw_text(developerName, COLOR_BLACK, "font_text", 26, (ARCADE_MACHINE_RES_X / 2) - 180,
+                      (ARCADE_MACHINE_RES_Y / 2) + 220 + developerNameSpacing * developerNameIndex);
             developerNameIndex++;
         }
 
         // Fill screen with white at alpha value (opacity)
         fill_rectangle(rgba_color(1.0, 1.0, 1.0, alpha), 0, 0, ARCADE_MACHINE_RES_X, ARCADE_MACHINE_RES_Y);
-        // Decrement i and alpha 
-        i--; alpha = alpha - 0.05;
+        // Decrement i and alpha
+        i--;
+        alpha = alpha - 0.05;
         // If alpha is == 0, hold image for 1.5 seconds
-        if (std::abs(alpha - 0.0) < 1e-9)
-        {
+        if (std::abs(alpha - 0.0) < 1e-9) {
             play_sound_effect("intro_start");
             delay(2000);
             /*  After this has happened, the alpha value will continue into the negatives
-                The colour function continues to accept negative alpha values, 
+                The colour function continues to accept negative alpha values,
                 effectively creating a fade out animation for the remainder of the while loop
             */
         }
@@ -336,19 +323,19 @@ void ArcadeMachine::playArcadeTeamIntro()
 }
 
 /**
-    Draws the Splashkit Productions logo to the screen and 
+    Draws the Splashkit Productions logo to the screen and
     fetches new games from Git repo
 */
 void ArcadeMachine::playSplashKitIntro()
 {
     // Pull the most recent version of the arcade-games repo.
-    do
-    {
+    do {
         // Draw SplashKit productions screen
         this->m_introSplashkit.drawTitlePage();
-        draw_text("Loading...", COLOR_SLATE_GRAY, "font_text", 60, ARCADE_MACHINE_RES_X / 2 - 100, ARCADE_MACHINE_RES_Y / 2 + 350);
+        draw_text("Loading...", COLOR_SLATE_GRAY, "font_text", 60, ARCADE_MACHINE_RES_X / 2 - 100,
+                  ARCADE_MACHINE_RES_Y / 2 + 350);
         refresh_screen();
-        
+
     } while (!this->m_config.getFromGit("https://github.com/thoth-tech/arcade-games.git", "games"));
 }
 

--- a/src/Button.cpp
+++ b/src/Button.cpp
@@ -1,53 +1,54 @@
 #include "Button.h"
 
 /**
-* @brief First Overloaded Constructor
-* 
-* @param c button type / color
-* @param scale size multiplier
-* 
-*/
+ * @brief First Overloaded Constructor
+ *
+ * @param c button type / color
+ * @param scale size multiplier
+ *
+ */
 Button::Button(Color c, float scale)
 {
     // button color
     this->m_btnColor = btn_color(c);
     // load button color image
-    //this->_pic = load_bitmap(to_string(c), this->_color);
+    // this->_pic = load_bitmap(to_string(c), this->_color);
     // create sprite from image
     this->m_btn = create_sprite(this->m_btnColor);
     // add hightlight layer to sprite
     sprite_add_layer(this->m_btn, this->m_btnHighlightPic, this->m_btnHighlightText);
     // scale the sprite
     sprite_set_scale(this->m_btn, scale);
-    // get the centre points of the sprite 
-    this->m_centreX = sprite_width(this->m_btn) /2;
-    this->m_centreY = sprite_height(this->m_btn)/2;
+    // get the centre points of the sprite
+    this->m_centreX = sprite_width(this->m_btn) / 2;
+    this->m_centreY = sprite_height(this->m_btn) / 2;
 }
-        
+
 /**
-* @brief Second Overloaded Constructor
-* Calculates the position in the window
-* 
-* @param c button type / color
-* @param x intended x-axis position in window
-* @param y intended y-axis position in window
-* @param xCell size of cell x-dimension 
-* @param yCell size of cell y-dimension
-* @param scale size multiplier
-*/
+ * @brief Second Overloaded Constructor
+ * Calculates the position in the window
+ *
+ * @param c button type / color
+ * @param x intended x-axis position in window
+ * @param y intended y-axis position in window
+ * @param xCell size of cell x-dimension
+ * @param yCell size of cell y-dimension
+ * @param scale size multiplier
+ */
 Button::Button(Color c, float x, float y, int xCell, int yCell, float scale)
-{ 
+{
     // button color
     this->m_btnColor = btn_color(c);
     // create sprite from image
     this->m_btn = create_sprite(this->m_btnColor);
     // add hightlight layer to sprite
     sprite_add_layer(this->m_btn, this->m_btnHighlightPic, this->m_btnHighlightText);
-    // get the centre points of the sprite 
-    this->m_centreX = sprite_width(this->m_btn) /2;
-    this->m_centreY = sprite_height(this->m_btn)/2;
-    // store the intended location 
-    this->m_x = x * xCell; m_y = y * yCell;
+    // get the centre points of the sprite
+    this->m_centreX = sprite_width(this->m_btn) / 2;
+    this->m_centreY = sprite_height(this->m_btn) / 2;
+    // store the intended location
+    this->m_x = x * xCell;
+    m_y = y * yCell;
     // set button sprite centre point to intended location
     sprite_set_x(this->m_btn, this->m_x - this->m_centreX);
     sprite_set_y(this->m_btn, this->m_y - this->m_centreY);
@@ -58,88 +59,86 @@ Button::Button(Color c, float x, float y, int xCell, int yCell, float scale)
 }
 
 /**
-* @brief Third Overloaded Constructor
-* Calculates the position in the window
-* 
-* @param c button type / color
-* @param image bitmap name
-* @param scale size multiplier
-*/
+ * @brief Third Overloaded Constructor
+ * Calculates the position in the window
+ *
+ * @param c button type / color
+ * @param image bitmap name
+ * @param scale size multiplier
+ */
 Button::Button(Color c, std::string image, float scale)
 {
     // button color
     this->m_btnColor = btn_color(c);
     // create bitmap from string
-    //this->_pic = load_bitmap(image, image);
+    // this->_pic = load_bitmap(image, image);
     // create sprite from image
     this->m_btn = create_sprite(image);
     // add hightlight layer to sprite
     sprite_add_layer(this->m_btn, this->m_btnHighlightPic, this->m_btnHighlightText);
     // scale the sprite
     sprite_set_scale(this->m_btn, scale);
-    // get the centre points of the sprite 
-    this->m_centreX = sprite_width(this->m_btn) /2;
-    this->m_centreY = sprite_height(this->m_btn)/2;
+    // get the centre points of the sprite
+    this->m_centreX = sprite_width(this->m_btn) / 2;
+    this->m_centreY = sprite_height(this->m_btn) / 2;
 }
 
 /**
-* @brief Gets the filepath to the requested color (image) 
-* 
-* @param c 
-* @return * string 
-*/
+ * @brief Gets the filepath to the requested color (image)
+ *
+ * @param c
+ * @return * string
+ */
 std::string Button::btn_color(Color c)
 {
     std::string filepath = "buttons/";
-    switch(c)
-    {
-        // Main Menu Buttons
-        case PLAY:
-            m_btnHighlightPic = bitmap_named("play_hghlt");
-            m_btnHighlightText = "play_highlight";
-            return "btn_play";
-            break;
-        case EXIT:
-            m_btnHighlightPic = bitmap_named("exit_hghlt");
-            m_btnHighlightText = "exit_highlight";
-            return "btn_exit";
-            break;
-        case OPTS:
-            m_btnHighlightPic = bitmap_named("options_hghlt");
-            m_btnHighlightText = "options_highlight";
-            return "btn_opts";
-            break;
-        
-        // Game Screen Buttons
-        case GAME:
-            m_btnHighlightPic = bitmap_named("game_hghlt");
-            m_btnHighlightText = "game_highlight";
-            return "";
-        
-        // Options Screen Buttons
-        case HOME:
-            m_btnHighlightPic = bitmap_named("opts_home_hghlt");
-            m_btnHighlightText = "opts_home_highlight";
-            return "opts_home";
-            break;
-        case SOUND:
-            m_btnHighlightPic = bitmap_named("opts_sound_hghlt");
-            m_btnHighlightText = "opts_sound_highlight";
-            return "opts_sound";
-            break;
-        case DISPLAY:
-            m_btnHighlightPic = bitmap_named("opts_display_hghlt");
-            m_btnHighlightText = "opts_display_highlight";
-            return "opts_display";
-            break;
-        case STATS:
-            m_btnHighlightPic = bitmap_named("opts_stats_hghlt");
-            m_btnHighlightText = "opts_stats_highlight";
-            return "opts_stats";
-            break;
-        default:
-            return "btn_play";
-            break;
+    switch (c) {
+    // Main Menu Buttons
+    case PLAY:
+        m_btnHighlightPic = bitmap_named("play_hghlt");
+        m_btnHighlightText = "play_highlight";
+        return "btn_play";
+        break;
+    case EXIT:
+        m_btnHighlightPic = bitmap_named("exit_hghlt");
+        m_btnHighlightText = "exit_highlight";
+        return "btn_exit";
+        break;
+    case OPTS:
+        m_btnHighlightPic = bitmap_named("options_hghlt");
+        m_btnHighlightText = "options_highlight";
+        return "btn_opts";
+        break;
+
+    // Game Screen Buttons
+    case GAME:
+        m_btnHighlightPic = bitmap_named("game_hghlt");
+        m_btnHighlightText = "game_highlight";
+        return "";
+
+    // Options Screen Buttons
+    case HOME:
+        m_btnHighlightPic = bitmap_named("opts_home_hghlt");
+        m_btnHighlightText = "opts_home_highlight";
+        return "opts_home";
+        break;
+    case SOUND:
+        m_btnHighlightPic = bitmap_named("opts_sound_hghlt");
+        m_btnHighlightText = "opts_sound_highlight";
+        return "opts_sound";
+        break;
+    case DISPLAY:
+        m_btnHighlightPic = bitmap_named("opts_display_hghlt");
+        m_btnHighlightText = "opts_display_highlight";
+        return "opts_display";
+        break;
+    case STATS:
+        m_btnHighlightPic = bitmap_named("opts_stats_hghlt");
+        m_btnHighlightText = "opts_stats_highlight";
+        return "opts_stats";
+        break;
+    default:
+        return "btn_play";
+        break;
     }
 }
-

--- a/src/ConfigData.cpp
+++ b/src/ConfigData.cpp
@@ -1,34 +1,33 @@
 #include "ConfigData.h"
 
-#include <regex>
 #include <iostream>
+#include <regex>
 #include <sys/stat.h>
 #include <sys/types.h>
 
 /**
-* @brief Construct a new Config Data object
-* 
-* @param configFile The config.txt file
-*/
+ * @brief Construct a new Config Data object
+ *
+ * @param configFile The config.txt file
+ */
 ConfigData::ConfigData(std::string configFile)
 {
     collectConfigData(readTxt(openFile(configFile)));
 }
 
 /**
-* @brief Generic open file function 
-* 
-* @param file The config.txt file
-* @return A file as ifstream object
-*/
+ * @brief Generic open file function
+ *
+ * @param file The config.txt file
+ * @return A file as ifstream object
+ */
 std::ifstream ConfigData::openFile(std::string file)
 {
     std::ifstream configFile;
 
     configFile.open(file);
 
-    if(configFile.fail())
-    {
+    if (configFile.fail()) {
         std::cerr << "Error Opening File" << std::endl;
         exit(1);
     }
@@ -37,11 +36,11 @@ std::ifstream ConfigData::openFile(std::string file)
 }
 
 /**
-* @brief Reads the contents of a file, ignoring comments indicated by '#'
-* 
-* @param file The ifstream object
-* @return An array of data from a text file
-*/
+ * @brief Reads the contents of a file, ignoring comments indicated by '#'
+ *
+ * @param file The ifstream object
+ * @return An array of data from a text file
+ */
 std::vector<std::string> ConfigData::readTxt(std::ifstream file)
 {
     std::vector<std::string> configItems;
@@ -49,56 +48,63 @@ std::vector<std::string> ConfigData::readTxt(std::ifstream file)
     char c = '#';
     char s = ' ';
 
-    while(getline(file, line)){
-        if(line[0] != c && line[0] != s)
-        {
+    while (getline(file, line)) {
+        if (line[0] != c && line[0] != s) {
             configItems.push_back(line);
         }
     }
-    
+
     return configItems;
 }
 
 /**
-* @brief Populates this config data with the data from the given array
-* 
-* @param configs a vector of strings
-* @return * void
-*/
+ * @brief Populates this config data with the data from the given array
+ *
+ * @param configs a vector of strings
+ * @return * void
+ */
 void ConfigData::collectConfigData(std::vector<std::string> configs)
 {
     std::smatch sm;
 
-    if (configs.size() > 0)
-    {
-        for (int i = 0; i < configs.size(); i++)
-        {
+    if (configs.size() > 0) {
+        for (int i = 0; i < configs.size(); i++) {
             const std::string s = configs[i];
 
-            if(std::regex_search(s.begin(), s.end(), sm, std::regex("(.*)=(.*)")))
-            {
-                     if (sm[1] == "title")       this->m_title = sm[2]; 
-                else if (sm[1] == "author")      this->m_author = sm[2];
-                else if (sm[1] == "genre")       this->m_genre = sm[2];
-                else if (sm[1] == "description") this->m_description = sm[2];
-                else if (sm[1] == "rating")      this->m_rating = sm[2];
-                else if (sm[1] == "language")    this->m_language = sm[2];
-                else if (sm[1] == "image")       this->m_image = sm[2];
-                else if (sm[1] == "win-exe")     this->m_win_exe = sm[2];
-                else if (sm[1] == "linux-bin")   this->m_lin_exe = sm[2];
-                else if (sm[1] == "macos-bin")   this->m_mac_exe = sm[2];
-                else if (sm[1] == "repository")  this->m_repo = sm[2];
+            if (std::regex_search(s.begin(), s.end(), sm, std::regex("(.*)=(.*)"))) {
+                if (sm[1] == "title")
+                    this->m_title = sm[2];
+                else if (sm[1] == "author")
+                    this->m_author = sm[2];
+                else if (sm[1] == "genre")
+                    this->m_genre = sm[2];
+                else if (sm[1] == "description")
+                    this->m_description = sm[2];
+                else if (sm[1] == "rating")
+                    this->m_rating = sm[2];
+                else if (sm[1] == "language")
+                    this->m_language = sm[2];
+                else if (sm[1] == "image")
+                    this->m_image = sm[2];
+                else if (sm[1] == "win-exe")
+                    this->m_win_exe = sm[2];
+                else if (sm[1] == "linux-bin")
+                    this->m_lin_exe = sm[2];
+                else if (sm[1] == "macos-bin")
+                    this->m_mac_exe = sm[2];
+                else if (sm[1] == "repository")
+                    this->m_repo = sm[2];
             }
         }
     }
 }
 
 /**
-* @brief Parses a json filepath as string to json object
-* 
-* @param filepath 
-* @return json 
-*/
+ * @brief Parses a json filepath as string to json object
+ *
+ * @param filepath
+ * @return json
+ */
 json ConfigData::readJson(std::string filepath)
 {
     json config_items = json_from_file(filepath);
@@ -106,48 +112,43 @@ json ConfigData::readJson(std::string filepath)
 }
 
 /**
-* @brief Add json strings to data object
-* 
-* @param json_configs 
-*/
+ * @brief Add json strings to data object
+ *
+ * @param json_configs
+ */
 void ConfigData::collectJsonData(json json_configs)
 {
-    this->m_repo     = json_read_string(json_configs, "repo");
+    this->m_repo = json_read_string(json_configs, "repo");
     this->m_language = json_read_string(json_configs, "language");
-    this->m_image    = json_read_string(json_configs, "image");
-    this->m_title    = json_read_string(json_configs, "title");
-    this->m_genre    = json_read_string(json_configs, "genre");
-    this->m_rating   = json_read_string(json_configs, "rating");
-    this->m_author   = json_read_string(json_configs, "author");
-    this->m_win_exe  = json_read_string(json_configs, "win-exe");
-    this->m_lin_exe  = json_read_string(json_configs, "lin-exe");
-    this->m_mac_exe  = json_read_string(json_configs, "mac-exe");
+    this->m_image = json_read_string(json_configs, "image");
+    this->m_title = json_read_string(json_configs, "title");
+    this->m_genre = json_read_string(json_configs, "genre");
+    this->m_rating = json_read_string(json_configs, "rating");
+    this->m_author = json_read_string(json_configs, "author");
+    this->m_win_exe = json_read_string(json_configs, "win-exe");
+    this->m_lin_exe = json_read_string(json_configs, "lin-exe");
+    this->m_mac_exe = json_read_string(json_configs, "mac-exe");
 }
 
 /**
-* @brief Clones a git repository given the URL and proposed directory name
-* 
-* @param url git repository url
-* @param dir directory to clone to
-* @return true 
-* @return false 
-*/
-bool ConfigData::getFromGit(std::string url, const char* dir)
+ * @brief Clones a git repository given the URL and proposed directory name
+ *
+ * @param url git repository url
+ * @param dir directory to clone to
+ * @return true
+ * @return false
+ */
+bool ConfigData::getFromGit(std::string url, const char *dir)
 {
     // info struct lets us query the directory to see if it exists
     struct stat info;
-    if (stat(dir, &info) != 0)
-    {
+    if (stat(dir, &info) != 0) {
         // cant access dir -- clone from scratch
         system(("git clone " + url + " " + dir).c_str());
-    }
-    else if (info.st_mode &S_IFDIR)
-    {
+    } else if (info.st_mode & S_IFDIR) {
         // dir exists -- pull instead
         system(("git -C " + std::string(dir) + " pull " + url).c_str());
-    }
-    else
-    {
+    } else {
         // dir does not exist -- clone from scratch
         system(("git clone " + url + " " + dir).c_str());
     }
@@ -156,20 +157,20 @@ bool ConfigData::getFromGit(std::string url, const char* dir)
 }
 
 /**
-* @brief Change the name of a directory
-* 
-* @param dir directory to change the name of
-*/
-void ConfigData::renameDir(const char* dir)
+ * @brief Change the name of a directory
+ *
+ * @param dir directory to change the name of
+ */
+void ConfigData::renameDir(const char *dir)
 {
     std::string error;
     int n = m_title.length();
-    char name[n+1];
+    char name[n + 1];
     strcpy(name, m_title.c_str());
-    try{
+    try {
         rename(dir, name);
         throw(error);
-    } catch(std::string error) {
+    } catch (std::string error) {
         std::cerr << "Name cannot be changed" << std::endl;
         std::cerr << error << std::endl;
         exit(1);
@@ -177,14 +178,14 @@ void ConfigData::renameDir(const char* dir)
 }
 
 /**
-* @brief Delete a directory
-* 
-* @param dir name of direcotry to delete
-*/
+ * @brief Delete a directory
+ *
+ * @param dir name of direcotry to delete
+ */
 void ConfigData::deleteDir(std::string dir)
 {
     std::string error;
-    try{
+    try {
         system(("rmdir -s -q " + dir).c_str());
         throw(error);
     } catch (std::string e) {
@@ -194,9 +195,9 @@ void ConfigData::deleteDir(std::string dir)
 }
 
 /**
-* @brief Print the data contained in this object
-* 
-*/
+ * @brief Print the data contained in this object
+ *
+ */
 void ConfigData::printConfigData()
 {
     std::string i = std::to_string(id());

--- a/src/GameScreenButton.cpp
+++ b/src/GameScreenButton.cpp
@@ -1,25 +1,21 @@
 #include "GameScreenButton.h"
 
 // First constructor
-GameScreenButton::GameScreenButton(Color c, float scale)
-     : Button(c, scale)
+GameScreenButton::GameScreenButton(Color c, float scale) : Button(c, scale)
 {
-
 }
 
 // Third constructor
-GameScreenButton::GameScreenButton(Color c, std::string s, float scale)
-     : Button(c, s, scale)
+GameScreenButton::GameScreenButton(Color c, std::string s, float scale) : Button(c, s, scale)
 {
-
 }
 
 /**
-* @brief returns the action 
-* 
-* @param keyinput 
-* @return string 
-*/
+ * @brief returns the action
+ *
+ * @param keyinput
+ * @return string
+ */
 std::string GameScreenButton::action(std::string keyinput)
 {
     return keyinput;

--- a/src/GridLayout.cpp
+++ b/src/GridLayout.cpp
@@ -1,14 +1,14 @@
 #include "GridLayout.h"
 
-#include <stdexcept> // used for std::out_of_range
 #include <iostream>
+#include <stdexcept> // used for std::out_of_range
 
 /**
-* Construct a new grid object with a fixed number of columns/rows
-* @param rows number of rows
-* @param cols number of columns
-* @param scaleToFit scale the image to fill the cell
-*/
+ * Construct a new grid object with a fixed number of columns/rows
+ * @param rows number of rows
+ * @param cols number of columns
+ * @param scaleToFit scale the image to fill the cell
+ */
 GridLayout::GridLayout(int rows, int cols, bool scaleToFit)
 {
     _scaleToFit = scaleToFit;
@@ -24,12 +24,12 @@ GridLayout::GridLayout(int rows, int cols, bool scaleToFit)
 }
 
 /**
-* @brief Construct a new Grid object with a dynamic number of columns per row
-* 
-* @param rows number of rows
-* @param colsArray array of columns per row
-* @param scaleToFit scale the image to fill the cell
-*/
+ * @brief Construct a new Grid object with a dynamic number of columns per row
+ *
+ * @param rows number of rows
+ * @param colsArray array of columns per row
+ * @param scaleToFit scale the image to fill the cell
+ */
 GridLayout::GridLayout(int rows, int colsArray[], bool scaleToFit)
 {
     // Add check to ensure that the length of colsArray matches the number of rows
@@ -38,8 +38,7 @@ GridLayout::GridLayout(int rows, int colsArray[], bool scaleToFit)
     _rows = rows;
     m_colsArray = colsArray;
     // Calculate the number of cells in the grid
-    for (size_t i = 0; i < rows; i++)
-    {
+    for (size_t i = 0; i < rows; i++) {
         // Sum of all columns in each row
         _cells += colsArray[i];
     }
@@ -56,32 +55,32 @@ void GridLayout::destroy()
 }
 
 /**
-* @brief Set the background
-* 
-* @param bmp bitmap to use as background
-*/
+ * @brief Set the background
+ *
+ * @param bmp bitmap to use as background
+ */
 void GridLayout::setBackground(bitmap bmp)
 {
     m_background = bmp;
 }
 
 /**
-* @brief Calculate the bitmap scaling factor
-* 
-* @param bmp bitmap to scale
-* @param cellWidth width of the cell
-* @param cellHeight height of the cell
-* @return drawing_options options
-*/
+ * @brief Calculate the bitmap scaling factor
+ *
+ * @param bmp bitmap to scale
+ * @param cellWidth width of the cell
+ * @param cellHeight height of the cell
+ * @return drawing_options options
+ */
 drawing_options GridLayout::bitmapScaleOpt(int bmpWidth, int bmpHeight, double cellWidth, double cellHeight, int span)
 {
     return option_scale_bmp((cellWidth / bmpWidth) * span, cellHeight / bmpHeight);
 }
 
 /**
-* @brief Draw the cell boundaries, to help with placement
-* 
-*/
+ * @brief Draw the cell boundaries, to help with placement
+ *
+ */
 void GridLayout::drawCells()
 {
     // Vertical offset between each cell
@@ -95,19 +94,16 @@ void GridLayout::drawCells()
 
     int index = 0;
     // Iterate over rows
-    for (size_t i = 0; i < _rows; i++)
-    {
+    for (size_t i = 0; i < _rows; i++) {
         // If user specified dynamic number of columns per row
-        if (_useColsArray)
-        {
+        if (_useColsArray) {
             // Update horizontal offset each row
             xOffset = current_window_width() / m_colsArray[i];
             // Number of columns to iterate over
             _cols = m_colsArray[i];
         }
         // Iterate over columns
-        for (size_t j = 0; j < _cols; j++)
-        {
+        for (size_t j = 0; j < _cols; j++) {
             draw_rectangle(COLOR_BLACK, (double)(xOffset * j), (double)(yOffset * i), (double)xOffset, (double)yOffset);
             ++index;
         }
@@ -115,9 +111,9 @@ void GridLayout::drawCells()
 }
 
 /**
-* @brief Draw the items in the grid
-* 
-*/
+ * @brief Draw the items in the grid
+ *
+ */
 void GridLayout::drawGrid()
 {
     if (m_background)
@@ -136,42 +132,35 @@ void GridLayout::drawGrid()
 
     int index = 0;
     // Iterate over rows
-    for (size_t i = 0; i < _rows; i++)
-    {
+    for (size_t i = 0; i < _rows; i++) {
         // If user specified dynamic number of columns per row
-        if (_useColsArray)
-        {
+        if (_useColsArray) {
             // Update horizontal offset each row
             xOffset = current_window_width() / m_colsArray[i];
             // Number of columns to iterate over
             _cols = m_colsArray[i];
         }
         // Iterate over columns
-        for (size_t j = 0; j < _cols; j++)
-        {
+        for (size_t j = 0; j < _cols; j++) {
             // Skip an iteration
-            if (skipIterations > 0)
-            {
+            if (skipIterations > 0) {
                 --skipIterations;
                 ++index;
                 continue;
             }
             // If the cell is not empty
-            if (_grid[index].cellType != EMPTY)
-            {
+            if (_grid[index].cellType != EMPTY) {
                 double x = (xOffset * j);
                 double y = (yOffset * i);
 
                 // Draw object into cell, centre using dimensions
-                switch (_grid[index].cellType)
-                {
+                switch (_grid[index].cellType) {
                 case BMP:
-                    if (_scaleToFit)
-                    {
-                        options = bitmapScaleOpt(bitmap_width(_grid[index].bmp), bitmap_height(_grid[index].bmp), xOffset, yOffset, _grid[index].span);
+                    if (_scaleToFit) {
+                        options = bitmapScaleOpt(bitmap_width(_grid[index].bmp), bitmap_height(_grid[index].bmp),
+                                                 xOffset, yOffset, _grid[index].span);
                     }
-                    if (_grid[index].centre)
-                    {
+                    if (_grid[index].centre) {
                         x = x + (((xOffset * _grid[index].span) - bitmap_width(_grid[index].bmp)) / 2);
                         y = y + ((yOffset - bitmap_height(_grid[index].bmp)) / 2);
                     }
@@ -180,8 +169,7 @@ void GridLayout::drawGrid()
                 case SPT:
                     if (_scaleToFit)
                         write("ScaleToFit: Feature not currently available with use of sprites.\n");
-                    if (_grid[index].centre)
-                    {
+                    if (_grid[index].centre) {
                         x = x + (((xOffset * _grid[index].span) - sprite_width(_grid[index].spr)) / 2);
                         y = y + ((yOffset - sprite_height(_grid[index].spr)) / 2);
                     }
@@ -190,8 +178,7 @@ void GridLayout::drawGrid()
                 case BTN:
                     if (_scaleToFit)
                         write("ScaleToFit: Feature not currently available with use of sprites.\n");
-                    if (_grid[index].centre)
-                    {
+                    if (_grid[index].centre) {
                         x = x + ((xOffset * _grid[index].span) / 2) - _grid[index].button->centreX();
                         y = y + _grid[index].button->centreY();
                     }
@@ -208,8 +195,7 @@ void GridLayout::drawGrid()
                 }
             }
             // If the cell spans multiple columns, skip the next iterations
-            if (_grid[index].span > 1)
-            {
+            if (_grid[index].span > 1) {
                 skipIterations = _grid[index].span - 1;
             }
             ++index;
@@ -218,47 +204,41 @@ void GridLayout::drawGrid()
 }
 
 /**
-* @brief Find a cell in the grid using row/col
-* 
-* @param row row of the cell
-* @param col column of the cell
-* @return int index of the cell
-*/
+ * @brief Find a cell in the grid using row/col
+ *
+ * @param row row of the cell
+ * @param col column of the cell
+ * @return int index of the cell
+ */
 int GridLayout::findCell(int row, int col)
 {
     int cellNum = 0;
     // Selected row is out of bounds
-    if (_rows <= row)
-    {
+    if (_rows <= row) {
         throw std::out_of_range("Row index out of range");
         return -1;
     }
     // Dynamic number of columns/row
-    if (_useColsArray)
-    {
+    if (_useColsArray) {
         // Selected column is out of bounds
-        if (m_colsArray[row] < col + 1)
-        {
+        if (m_colsArray[row] < col + 1) {
             throw std::out_of_range("Column index out of range");
             return -1;
         }
         // Calculate the cell number
-        for (size_t i = 0; i < row; i++)
-        {
+        for (size_t i = 0; i < row; i++) {
             cellNum += m_colsArray[i];
         }
 
         cellNum += col;
     }
     // Selected column is out of bounds
-    else if (_cols <= col)
-    {
+    else if (_cols <= col) {
         throw std::out_of_range("Column index out of range");
         return -1;
     }
     // Fixed number of columns
-    else
-    {
+    else {
         // Calculate the cell number
         cellNum = row * _cols + col;
     }
@@ -266,29 +246,29 @@ int GridLayout::findCell(int row, int col)
 }
 
 /**
-* @brief Get a cell from the grid using row/col
-* 
-* @param row row of the cell
-* @param col column of the cell
-* @return cell* pointer to the cell
-*/
+ * @brief Get a cell from the grid using row/col
+ *
+ * @param row row of the cell
+ * @param col column of the cell
+ * @return cell* pointer to the cell
+ */
 Cell GridLayout::getCell(int row, int col)
 {
     return _grid[findCell(row, col)];
 }
 
 /**
-* @brief Update a cell with a specified bitmap
-* 
-* @param bmp bitmap to update the cell with
-* @param row row of the cell
-* @param col column of the cell
-* @param span number of columns the bitmap spans
-* @param centre whether the bitmap should be centered
-*/
+ * @brief Update a cell with a specified bitmap
+ *
+ * @param bmp bitmap to update the cell with
+ * @param row row of the cell
+ * @param col column of the cell
+ * @param span number of columns the bitmap spans
+ * @param centre whether the bitmap should be centered
+ */
 void GridLayout::updateCell(const bitmap &bmp, int row, int col, int span, bool centre)
 {
-    _gridEmpty=false;
+    _gridEmpty = false;
     // Stores the index of the cell
     int cellNum = findCell(row, col);
     // Selected row is out of bounds
@@ -302,17 +282,17 @@ void GridLayout::updateCell(const bitmap &bmp, int row, int col, int span, bool 
 }
 
 /**
-* @brief Update a cell with a specified sprite
-* 
-* @param sprite sprite to update the cell with
-* @param row row of the cell
-* @param col column of the cell
-* @param span number of columns the sprite spans
-* @param centre whether the sprite should be centered
-*/
+ * @brief Update a cell with a specified sprite
+ *
+ * @param sprite sprite to update the cell with
+ * @param row row of the cell
+ * @param col column of the cell
+ * @param span number of columns the sprite spans
+ * @param centre whether the sprite should be centered
+ */
 void GridLayout::updateCell(const sprite &sprite, int row, int col, int span, bool centre)
 {
-    _gridEmpty=false;
+    _gridEmpty = false;
     // Stores the index of the cell
     int cellNum = findCell(row, col);
     // Selected row is out of bounds
@@ -326,17 +306,17 @@ void GridLayout::updateCell(const sprite &sprite, int row, int col, int span, bo
 }
 
 /**
-* @brief Update a cell with a specified button
-* 
-* @param button button to update the cell with
-* @param row row of the cell
-* @param col column of the cell
-* @param span number of columns the button spans
-* @param centre whether the button should be centered
-*/
+ * @brief Update a cell with a specified button
+ *
+ * @param button button to update the cell with
+ * @param row row of the cell
+ * @param col column of the cell
+ * @param span number of columns the button spans
+ * @param centre whether the button should be centered
+ */
 void GridLayout::updateCell(Button *button, int row, int col, int span, bool centre)
 {
-    _gridEmpty=false;
+    _gridEmpty = false;
     // Stores the index of the cell
     int cellNum = findCell(row, col);
     // Selected row is out of bounds
@@ -350,17 +330,16 @@ void GridLayout::updateCell(Button *button, int row, int col, int span, bool cen
 }
 
 /**
-* @brief Update all cells with a specified bitmap
-* 
-* @param bmp bitmap to update the cells with
-* @param centre whether the bitmaps should be centered
-*/
+ * @brief Update all cells with a specified bitmap
+ *
+ * @param bmp bitmap to update the cells with
+ * @param centre whether the bitmaps should be centered
+ */
 void GridLayout::updateAllCells(bitmap bmp, bool centre)
 {
-    _gridEmpty=false;
+    _gridEmpty = false;
     // Iterate over all the cells
-    for (size_t i = 0; i < _cells; i++)
-    {
+    for (size_t i = 0; i < _cells; i++) {
         // Update bitmap
         _grid[i].cellType = BMP;
         _grid[i].spr = NULL;
@@ -370,17 +349,16 @@ void GridLayout::updateAllCells(bitmap bmp, bool centre)
 }
 
 /**
-* @brief Update all cells with a specified sprite
-* 
-* @param sprite sprite to update the cells with
-* @param centre whether the sprites should be centered
-*/
+ * @brief Update all cells with a specified sprite
+ *
+ * @param sprite sprite to update the cells with
+ * @param centre whether the sprites should be centered
+ */
 void GridLayout::updateAllCells(sprite sprite, bool centre)
 {
-    _gridEmpty=false;
+    _gridEmpty = false;
     // Iterate over all the cells
-    for (size_t i = 0; i < _cells; i++)
-    {
+    for (size_t i = 0; i < _cells; i++) {
         // Update bitmap
         _grid[i].cellType = SPT;
         _grid[i].spr = sprite;
@@ -390,9 +368,9 @@ void GridLayout::updateAllCells(sprite sprite, bool centre)
 }
 
 /**
-* @brief Log the dimensions of the cells to console
-* 
-*/
+ * @brief Log the dimensions of the cells to console
+ *
+ */
 void GridLayout::drawLayout()
 {
     int colWidth = 0;
@@ -400,16 +378,13 @@ void GridLayout::drawLayout()
     write("rowHeight: " + std::to_string(current_window_height() / _rows) + "\n");
     if (!_useColsArray)
         colWidth = current_window_width() / _cols;
-    for (size_t i = 0; i < _rows; i++)
-    {
-        if (_useColsArray)
-        {
+    for (size_t i = 0; i < _rows; i++) {
+        if (_useColsArray) {
             colWidth = current_window_width() / m_colsArray[i];
             _cols = m_colsArray[i];
         }
         write("Row " + std::to_string(i) + " (colWidth: " + std::to_string(colWidth) + "): ");
-        for (size_t j = 0; j < _cols; j++)
-        {
+        for (size_t j = 0; j < _cols; j++) {
             string content = "[" + std::to_string(i) + "," + std::to_string(j) + "]";
             write(content);
         }
@@ -418,16 +393,15 @@ void GridLayout::drawLayout()
 }
 
 /**
-* @brief Clear the grid
-* 
-*/
+ * @brief Clear the grid
+ *
+ */
 void GridLayout::clearGrid()
 {
     if (_gridEmpty)
         return;
     // Iterate over all the cells
-    for (size_t i = 0; i < _cells; i++)
-    {
+    for (size_t i = 0; i < _cells; i++) {
         // Reset cell to default
         _grid[i].cellType = EMPTY;
         _grid[i].spr = NULL;
@@ -436,26 +410,24 @@ void GridLayout::clearGrid()
         _grid[i].centre = true;
     }
     // Grid is now empty
-    _gridEmpty = true;  
+    _gridEmpty = true;
 }
 
 /**
-* @brief Find the nearest cells row/col from x, y coordinates
-* 
-* @param x x-coordinate (px)
-* @param y y-coordinate (px)
-* @return point_2d 
-*/
+ * @brief Find the nearest cells row/col from x, y coordinates
+ *
+ * @param x x-coordinate (px)
+ * @param y y-coordinate (px)
+ * @return point_2d
+ */
 point_2d GridLayout::findCellFromLoc(int x, int y)
 {
     int rowNum;
     // Selected row is out of bounds
     int yOffset = current_window_height() / _rows;
     int runningSum = 0;
-    for (int i = 0; i < _rows; i++)
-    {
-        if (y >= runningSum && y < runningSum + yOffset)
-        {
+    for (int i = 0; i < _rows; i++) {
+        if (y >= runningSum && y < runningSum + yOffset) {
             rowNum = i;
         }
         runningSum += yOffset;
@@ -467,10 +439,8 @@ point_2d GridLayout::findCellFromLoc(int x, int y)
         xOffset = (current_window_width() / _cols);
     runningSum = 0;
     int colNum;
-    for (int i = 0; i < _cols; i++)
-    {
-        if (x >= runningSum && x < runningSum  + xOffset)
-        {
+    for (int i = 0; i < _cols; i++) {
+        if (x >= runningSum && x < runningSum + xOffset) {
             colNum = i;
         }
         runningSum += xOffset;
@@ -482,9 +452,9 @@ point_2d GridLayout::findCellFromLoc(int x, int y)
 }
 
 /**
-* @brief Clear the cell
-* 
-*/
+ * @brief Clear the cell
+ *
+ */
 void GridLayout::clearCell(int row, int col)
 {
     // Gets the index of the cell

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -5,7 +5,9 @@
 Menu::Menu()
 {
     this->m_db = new Database();
-    Table *gameDataTable = new Table("gameData", {{"gameName", "TEXT"}, {"startTime", "TEXT"}, {"endTime", "TEXT"}, {"rating", "TEXT"}, {"highScore", "TEXT"}});
+    Table *gameDataTable = new Table(
+        "gameData",
+        {{"gameName", "TEXT"}, {"startTime", "TEXT"}, {"endTime", "TEXT"}, {"rating", "TEXT"}, {"highScore", "TEXT"}});
     this->m_db->createTable(gameDataTable);
     this->m_rating = Rating();
 }
@@ -14,7 +16,9 @@ Menu::Menu(std::vector<ConfigData> configs)
 {
     this->m_games = configs;
     this->m_db = new Database();
-    Table *gameDataTable = new Table("gameData", {{"gameName", "TEXT"}, {"startTime", "TEXT"}, {"endTime", "TEXT"}, {"rating", "TEXT"}, {"highScore", "TEXT"}});
+    Table *gameDataTable = new Table(
+        "gameData",
+        {{"gameName", "TEXT"}, {"startTime", "TEXT"}, {"endTime", "TEXT"}, {"rating", "TEXT"}, {"highScore", "TEXT"}});
     this->m_db->createTable(gameDataTable);
     this->m_rating = Rating();
 #ifdef _WIN32
@@ -30,18 +34,17 @@ Menu::~Menu()
     delete m_tip;
 }
 
-/** 
-* @brief Gets the game images from the config files and returns vector of game images.
-* 
-* @param configs Vector of config data.
-* @return vector of game images.
-*/
+/**
+ * @brief Gets the game images from the config files and returns vector of game images.
+ *
+ * @param configs Vector of config data.
+ * @return vector of game images.
+ */
 std::vector<std::string> Menu::getGameSprites(std::vector<ConfigData> configs)
 {
     std::vector<std::string> gameImages;
 
-    for (int i = 0; i < configs.size(); i++)
-    {
+    for (int i = 0; i < configs.size(); i++) {
         // Get image dir and image name from games vector.
         std::string image = configs[i].folder() + "/" + configs[i].image();
         gameImages.push_back(image);
@@ -50,10 +53,9 @@ std::vector<std::string> Menu::getGameSprites(std::vector<ConfigData> configs)
     return gameImages;
 }
 
-
 /**
-* @brief Create a grid object
-*/
+ * @brief Create a grid object
+ */
 void Menu::createGrid()
 {
     // Instantiate grid object
@@ -64,25 +66,21 @@ void Menu::createGrid()
 }
 
 /**
-* @brief Create a list of games.
-* 
-*/
+ * @brief Create a list of games.
+ *
+ */
 void Menu::createButtons()
 {
     // Call function to get game images.
     m_gameImages = getGameSprites(m_games);
     GameData gameStats;
 
-    for (int i = 0; i < m_gameImages.size(); i++)
-    {
-        if (i == 0)
-        {
+    for (int i = 0; i < m_gameImages.size(); i++) {
+        if (i == 0) {
             this->m_button = new ButtonNode(new GameScreenButton(Button::GAME, m_gameImages[0]));
             this->m_button->config = m_games[0];
             this->m_button->stats = gameStats.getStats(this->m_db, m_games[0].title());
-        }
-        else
-        {
+        } else {
             std::string image = m_gameImages[i];
             this->m_button->addBefore(new ButtonNode(new GameScreenButton(Button::GAME, image)));
             this->m_button->getPrev()->config = m_games[i];
@@ -91,9 +89,9 @@ void Menu::createButtons()
     }
 }
 
-/** 
-* @brief create a tip to display to the user.
-*/
+/**
+ * @brief create a tip to display to the user.
+ */
 void Menu::createTip()
 {
     bitmap bmpTip = bitmap_named("information");
@@ -102,27 +100,21 @@ void Menu::createTip()
     animation anim = create_animation(infoScript, "rotate");
     drawing_options opt = option_with_animation(anim);
 
-    std::string tipText[3] = {
-        "Use the left and right arrow keys to cycle through the carousel", 
-        "Press escape to return to the main menu", 
-        "Press enter to start the game"
-    };
-    this->m_tip = new Tip(tipText[rand()%3], bmpTip, anim, opt, 3000, 25);
+    std::string tipText[3] = {"Use the left and right arrow keys to cycle through the carousel",
+                              "Press escape to return to the main menu", "Press enter to start the game"};
+    this->m_tip = new Tip(tipText[rand() % 3], bmpTip, anim, opt, 3000, 25);
 }
 
 /**
-* @brief draw the game buttons to the window, using the carousel layout
-*/
+ * @brief draw the game buttons to the window, using the carousel layout
+ */
 void Menu::updateCarousel()
 {
     // If menu is sliding then clear the grid.
-    if (this->m_menuSliding)
-    {
+    if (this->m_menuSliding) {
         this->m_grid.clearGrid();
-    }
-    else {
-        if (this->m_button && !this->m_inGame)
-        {
+    } else {
+        if (this->m_button && !this->m_inGame) {
             this->m_grid.updateCell(this->m_button->getPrev()->button, 2, 0, 1, false);
             this->m_grid.updateCell(this->m_button->button, 2, 5, 1, false);
             this->m_grid.updateCell(this->m_button->getNext()->button, 2, 10, 1, false);
@@ -131,8 +123,8 @@ void Menu::updateCarousel()
 }
 
 /**
-* @brief m_handle carousel input
-*/
+ * @brief m_handle carousel input
+ */
 void Menu::carouselHandler()
 {
     /// Check for input in selector class.
@@ -143,16 +135,11 @@ void Menu::carouselHandler()
     checkGameExit();
 #endif
 
-    if (this->m_button)
-    {
-        if (this->m_action == "escape" && m_overlayActive)
-        {
+    if (this->m_button) {
+        if (this->m_action == "escape" && m_overlayActive) {
             m_overlayActive = false;
-        }
-        else if (this->m_action == "return")
-        {
-            if (m_overlayActive)
-            {
+        } else if (this->m_action == "return") {
+            if (m_overlayActive) {
 #ifdef _WIN32
                 // Get game path
                 m_gamePath = (this->m_button->config.folder() + "/" + this->m_button->config.win_exe()).c_str();
@@ -175,7 +162,7 @@ void Menu::carouselHandler()
                 this->m_grid.clearGrid();
                 // set new background
                 this->m_grid.setBackground(bitmap_named("in_game_bgnd"));
-                //turn off overlay
+                // turn off overlay
                 this->m_overlayActive = false;
                 // turn off menu music
                 fade_music_out(1000);
@@ -197,22 +184,21 @@ void Menu::carouselHandler()
 }
 
 /**
-* @brief draw the menu page
-*/
+ * @brief draw the menu page
+ */
 void Menu::drawMenuPage()
 {
     // if the game has ended, go back to games menu
-    if(!this->m_inGame && this->m_gameStarted)
-    {
+    if (!this->m_inGame && this->m_gameStarted) {
         this->m_gameStarted = false;
         backToGamesMenu();
         m_gameData.setRating(m_rating.getRating());
         m_gameData.writeData(this->m_db);
         this->m_button->stats = m_gameData.getStats(this->m_db, m_gameData.getGameName());
     }
-    
+
     this->m_grid.drawGrid();
-    
+
     // Wait for selector to key input to determine slide direction.
     if (m_selectorGamesMenu.getSlideLeft())
         drawUpdateSlideLeft();
@@ -229,12 +215,12 @@ void Menu::drawMenuPage()
 }
 
 /**
-* @brief Method to update the sprite positions and draw sprite.
-* 
-* @param buttonSprite The buttons sprite.
-* @param position The position to move the sprite.
-* @return ** void 
-*/
+ * @brief Method to update the sprite positions and draw sprite.
+ *
+ * @param buttonSprite The buttons sprite.
+ * @param position The position to move the sprite.
+ * @return ** void
+ */
 void Menu::updateSlide(sprite buttonSprite, int position)
 {
     // Show the base layer of sprite.
@@ -250,10 +236,10 @@ void Menu::updateSlide(sprite buttonSprite, int position)
 }
 
 /**
-* @brief Slide the game buttons on left key input.
-* 
-* @return ** void 
-*/
+ * @brief Slide the game buttons on left key input.
+ *
+ * @return ** void
+ */
 void Menu::drawUpdateSlideLeft()
 {
     this->m_menuSliding = true;
@@ -274,8 +260,7 @@ void Menu::drawUpdateSlideLeft()
     updateSlide(this->m_newButton3, this->m_pos3);
 
     // If sprite reaches position.
-    if (this->m_pos1 > 1300)
-    {
+    if (this->m_pos1 > 1300) {
         // Set selector bool back to false.
         m_selectorGamesMenu.setSlideLeft(false);
         this->m_menuSliding = false;
@@ -287,10 +272,10 @@ void Menu::drawUpdateSlideLeft()
 }
 
 /**
-* @brief Slide the game buttons on right key input.
-* 
-* @return ** void 
-*/
+ * @brief Slide the game buttons on right key input.
+ *
+ * @return ** void
+ */
 void Menu::drawUpdateSlideRight()
 {
     this->m_menuSliding = true;
@@ -310,8 +295,7 @@ void Menu::drawUpdateSlideRight()
     updateSlide(this->m_newButton2, this->m_pos4);
     updateSlide(this->m_newButton3, this->m_pos5);
 
-    if (this->m_pos1 <= 20)
-    {
+    if (this->m_pos1 <= 20) {
         // Set selector bool back to false.
         m_selectorGamesMenu.setSlideRight(false);
         this->m_menuSliding = false;
@@ -323,17 +307,18 @@ void Menu::drawUpdateSlideRight()
 }
 
 /**
-* @brief Draw an overlay over the game, using data from the config.
-* 
-* @param config the game config.
-*/
+ * @brief Draw an overlay over the game, using data from the config.
+ *
+ * @param config the game config.
+ */
 void Menu::drawOverlay(ConfigData config, GameData stats)
 {
     int xOffset = (current_window_width() / 2) + (current_window_width() / 14);
     int yStart = current_window_height() / 6;
     int yOffset = current_window_height() / 40;
 
-    fill_rectangle(rgba_color(0.0, 0.0, 0.0, 0.8), (current_window_width() / 2), 0, (current_window_width() / 2), current_window_height());
+    fill_rectangle(rgba_color(0.0, 0.0, 0.0, 0.8), (current_window_width() / 2), 0, (current_window_width() / 2),
+                   current_window_height());
     draw_text(config.title(), COLOR_WHITE, "font_title", yOffset * 3, xOffset, yStart);
     yStart += yOffset * 3;
     draw_text("Author: " + config.author(), COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (1 * yOffset));
@@ -341,45 +326,43 @@ void Menu::drawOverlay(ConfigData config, GameData stats)
     draw_text("Language: " + config.language(), COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (3 * yOffset));
     draw_text("Classification: " + config.rating(), COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (4 * yOffset));
     draw_text("Repository: " + config.repo(), COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (5 * yOffset));
-    draw_text("Playtime: " + std::to_string(stats.getStartTime()/60) + "mins", COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (6*yOffset));
+    draw_text("Playtime: " + std::to_string(stats.getStartTime() / 60) + "mins", COLOR_WHITE, "font_text", yOffset,
+              xOffset, yStart + (6 * yOffset));
     draw_text("Rating: ", COLOR_WHITE, "font_text", yOffset, xOffset, yStart + (7 * yOffset));
     string rating = string(stats.getRating(), 'J');
-    rating += string(5-rating.size(),'I');
-    draw_text(rating, COLOR_WHITE, "font_star", yOffset+10, xOffset + 90,  yStart + (7 * yOffset));
+    rating += string(5 - rating.size(), 'I');
+    draw_text(rating, COLOR_WHITE, "font_star", yOffset + 10, xOffset + 90, yStart + (7 * yOffset));
 }
 
 #ifdef _WIN32
 /**
-* @brief  Find the game window and bring it to focus, if it exists
-* 
-* @param windowName the name of the window
-* @param timeout time in ms to search for the window
-* @return true/false if window was found.
-*/
+ * @brief  Find the game window and bring it to focus, if it exists
+ *
+ * @param windowName the name of the window
+ * @param timeout time in ms to search for the window
+ * @return true/false if window was found.
+ */
 bool Menu::focusWindow(std::string windowName, int timeout)
 {
-    LPCSTR gameWindow =  windowName.c_str();
+    LPCSTR gameWindow = windowName.c_str();
     HWND gameWindowHandle = NULL;
 
     int timeElapsed;
     auto startTime = std::chrono::steady_clock::now();
 
-    //Find the window m_handle
+    // Find the window m_handle
     do {
-        gameWindowHandle = FindWindowEx(NULL,NULL,NULL, gameWindow);
-        timeElapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
+        gameWindowHandle = FindWindowEx(NULL, NULL, NULL, gameWindow);
+        timeElapsed =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - startTime).count();
         delay(250);
-    }
-    while (gameWindowHandle == NULL && timeElapsed <= timeout);
+    } while (gameWindowHandle == NULL && timeElapsed <= timeout);
 
-    //Maximise the Window
-    if (gameWindowHandle != NULL)
-    {
+    // Maximise the Window
+    if (gameWindowHandle != NULL) {
         ShowWindow(gameWindowHandle, SW_SHOWMAXIMIZED);
         return true;
-    }
-    else
-    {
+    } else {
         write_line("Unable to find gameWindow m_handle");
         return false;
     }
@@ -387,17 +370,16 @@ bool Menu::focusWindow(std::string windowName, int timeout)
 }
 
 /**
-* @brief Starts up the selected game by starting a new process.
-* 
-* @param gamePath The filepath of the game to open.
-* @param gameExe The executable of the game.
-* @param gameDirectory // The directory of the game.
-* @return ** void 
-*/
-void Menu::startGame(LPCSTR gamePath,LPSTR gameExe, LPCSTR gameDirectory)
+ * @brief Starts up the selected game by starting a new process.
+ *
+ * @param gamePath The filepath of the game to open.
+ * @param gameExe The executable of the game.
+ * @param gameDirectory // The directory of the game.
+ * @return ** void
+ */
+void Menu::startGame(LPCSTR gamePath, LPSTR gameExe, LPCSTR gameDirectory)
 {
-    if (!this->m_inGame)
-    {
+    if (!this->m_inGame) {
         // Additional info
         STARTUPINFOA startupInfo;
 
@@ -407,26 +389,24 @@ void Menu::startGame(LPCSTR gamePath,LPSTR gameExe, LPCSTR gameDirectory)
         ZeroMemory(&m_processInfo, sizeof(m_processInfo));
 
         // Start the program up
-        WINBOOL gameProcess = CreateProcessA
-        (
-            gamePath,               // the path
-            gameExe,                // Command line
-            NULL,                   // Process m_handle not inheritable
-            NULL,                   // Thread m_handle not inheritable
-            FALSE,                  // Set m_handle inheritance to FALSE
-            NORMAL_PRIORITY_CLASS,     // Don't open file in a separate console
-            NULL,                    // Use parent's environment block
-            gameDirectory,           // Use parent's starting directory
-            &startupInfo,            // Pointer to STARTUPINFO structure
-            &m_processInfo           // Pointer to PROCESS_INFORMATION structure
+        WINBOOL gameProcess = CreateProcessA(gamePath,              // the path
+                                             gameExe,               // Command line
+                                             NULL,                  // Process m_handle not inheritable
+                                             NULL,                  // Thread m_handle not inheritable
+                                             FALSE,                 // Set m_handle inheritance to FALSE
+                                             NORMAL_PRIORITY_CLASS, // Don't open file in a separate console
+                                             NULL,                  // Use parent's environment block
+                                             gameDirectory,         // Use parent's starting directory
+                                             &startupInfo,          // Pointer to STARTUPINFO structure
+                                             &m_processInfo         // Pointer to PROCESS_INFORMATION structure
         );
 
-        OpenProcess(PROCESS_QUERY_INFORMATION,TRUE, gameProcess);
+        OpenProcess(PROCESS_QUERY_INFORMATION, TRUE, gameProcess);
 
         std::string windowName = gameExe;
-        //Remove the extension from the application name (.exe)
+        // Remove the extension from the application name (.exe)
         windowName = windowName.substr(0, windowName.find("."));
-        //Focus the window
+        // Focus the window
         focusWindow(windowName);
 
         this->m_inGame = true;
@@ -434,21 +414,19 @@ void Menu::startGame(LPCSTR gamePath,LPSTR gameExe, LPCSTR gameDirectory)
 }
 
 /**
-* @brief Waits for game to exit.
-* 
-* @return ** void 
-*/
+ * @brief Waits for game to exit.
+ *
+ * @return ** void
+ */
 void Menu::checkGameExit()
 {
-    if (this->m_inGame == true)
-    {
+    if (this->m_inGame == true) {
         this->m_gameStarted = true;
         // Check if game has been exited.
         this->m_programExit = GetExitCodeProcess(m_processInfo.hProcess, &m_exitCode);
-        if ((this->m_programExit) && (STILL_ACTIVE != m_exitCode))
-        {
+        if ((this->m_programExit) && (STILL_ACTIVE != m_exitCode)) {
             this->m_inGame = false;
-            
+
             int highScore = 0;
             m_gameData.setEndTime(time(0));
             m_gameData.setHighScore(highScore);
@@ -457,9 +435,9 @@ void Menu::checkGameExit()
 }
 #endif
 
-/** 
-* @brief Fade back to games menu
-*/
+/**
+ * @brief Fade back to games menu
+ */
 void Menu::backToGamesMenu()
 {
     // fade to black
@@ -471,12 +449,12 @@ void Menu::backToGamesMenu()
 }
 
 /**
-* @brief Creates a fading effect
-* 
-* @param alphaStart The starting alpha value.
-* @param alphaEnd The ending alpha value.
-* @param alphaStep The alpha value to increment/decrement by.
-*/
+ * @brief Creates a fading effect
+ *
+ * @param alphaStart The starting alpha value.
+ * @param alphaEnd The ending alpha value.
+ * @param alphaStep The alpha value to increment/decrement by.
+ */
 void Menu::fade(double alphaStart, double alphaEnd, double alphaStep)
 {
     if (alphaStart > alphaEnd)
@@ -485,8 +463,7 @@ void Menu::fade(double alphaStart, double alphaEnd, double alphaStep)
     double difference = std::abs(alphaEnd - alphaStart);
     int steps = difference / std::abs(alphaStep);
 
-    for (int i = 0; i < steps; i++)
-    {
+    for (int i = 0; i < steps; i++) {
         clear_screen();
         this->m_grid.drawGrid();
         // Alpha value manipulates to the opacity of the rectangle.

--- a/src/MenuButton.cpp
+++ b/src/MenuButton.cpp
@@ -1,35 +1,30 @@
 #include "MenuButton.h"
 
 // First constructor
-MenuButton::MenuButton(Color c, float scale)
-     : Button(c, scale)
+MenuButton::MenuButton(Color c, float scale) : Button(c, scale)
 {
-
 }
 
 /**
-* @brief The action of this button
-* Called when the selector receives input for this button
-* 
-* @param keyinput 
-* @return string
-*/
+ * @brief The action of this button
+ * Called when the selector receives input for this button
+ *
+ * @param keyinput
+ * @return string
+ */
 std::string MenuButton::action(std::string keyinput)
 {
-    if (this->color() == btn_color(Button::PLAY))
-    {
+    if (this->color() == btn_color(Button::PLAY)) {
         // go to this screen
         write_line("Play");
         return "play";
     }
-    if (this->color() == btn_color(Button::EXIT))
-    {
+    if (this->color() == btn_color(Button::EXIT)) {
         // go to this screen
         write_line("Exit");
         return "exit";
     }
-    if (this->color() == btn_color(Button::OPTS))
-    {
+    if (this->color() == btn_color(Button::OPTS)) {
         // go to this screen
         write_line("Options");
         return "options";
@@ -38,10 +33,10 @@ std::string MenuButton::action(std::string keyinput)
 }
 
 /**
-* @brief Draws button to screen
-* 
-* @return * void 
-*/
+ * @brief Draws button to screen
+ *
+ * @return * void
+ */
 void MenuButton::drawButton()
 {
     draw_sprite(this->m_btn);

--- a/src/Option.cpp
+++ b/src/Option.cpp
@@ -1,10 +1,12 @@
 #include "Option.h"
 
-Option::Option() {}
+Option::Option()
+{
+}
 
 void Option::createOptionsButtons()
 {
-    // Initialise grid 
+    // Initialise grid
     GridLayout grid(ROWS, COLS);
     this->m_grid = grid;
 
@@ -13,13 +15,13 @@ void Option::createOptionsButtons()
     this->m_audio = audio;
 
     // Do we need config data in the options menu ?? maybe we will..
-    //this->m_configs = this->m_helper.ConfigDataList();
+    // this->m_configs = this->m_helper.ConfigDataList();
     // Create options buttons
     Button *home = new OptionsScreenButton(Button::HOME, 0.5);
     Button *sound = new OptionsScreenButton(Button::SOUND, 0.5);
     Button *stats = new OptionsScreenButton(Button::STATS, 0.5);
     Button *display = new OptionsScreenButton(Button::DISPLAY, 0.5);
-    
+
     // Add options buttons to local vector
     this->m_optionsBtns.push_back(home);
     this->m_optionsBtns.push_back(sound);
@@ -28,7 +30,7 @@ void Option::createOptionsButtons()
 
     // Fetch options menu background
     bitmap options_thoth = bitmap_named("options_thoth");
-    
+
     // Update grid cells with brackground asset
     this->m_grid.setBackground(options_thoth);
 
@@ -45,7 +47,7 @@ void Option::createOptionsButtons()
     this->m_grid.updateCell(m_optionsButtonNode->getPrev()->getPrev()->button, 2, 1);
 }
 
-void Option::drawOptionsMenu() 
+void Option::drawOptionsMenu()
 {
     // Get mouse position
     this->m_mouse = mouse_position();
@@ -57,14 +59,14 @@ void Option::drawOptionsMenu()
     // draw_sprite(this->m_selectorMainMenu.getCursor());
 
     // Get button postions
-    Cell home = this->m_grid.getCell(0,1);
-    Cell sound = this->m_grid.getCell(1,1);
-    Cell display = this->m_grid.getCell(3,1);
-    Cell stats = this->m_grid.getCell(2,1);
+    Cell home = this->m_grid.getCell(0, 1);
+    Cell sound = this->m_grid.getCell(1, 1);
+    Cell display = this->m_grid.getCell(3, 1);
+    Cell stats = this->m_grid.getCell(2, 1);
 
     // Options title text
     int font_size = 100;
-    draw_text("Options", COLOR_BLACK, "font_title", font_size, (ARCADE_MACHINE_RES_X/4), 50);
+    draw_text("Options", COLOR_BLACK, "font_title", font_size, (ARCADE_MACHINE_RES_X / 4), 50);
 
     // Check input in selector class.
     this->m_optionsButtonNode = this->m_selectorOptionsMenu.checkKeyInput(this->m_optionsButtonNode);
@@ -72,18 +74,22 @@ void Option::drawOptionsMenu()
     int x_pos = home.button->x() + (sprite_width(home.button->btn()) - 40);
     int y_pos;
 
-         if (this->m_optionsButtonNode->button->color() == "opts_home")    y_pos = home.button->y() + ((sprite_width(home.button->btn())*0.5)-30);
-    else if (this->m_optionsButtonNode->button->color() == "opts_sound")   y_pos = sound.button->y() + ((sprite_width(sound.button->btn())*0.5)-30);
-    else if (this->m_optionsButtonNode->button->color() == "opts_display") y_pos = display.button->y() + ((sprite_width(display.button->btn())*0.5)-30);
-    else if (this->m_optionsButtonNode->button->color() == "opts_stats")   y_pos = stats.button->y() + ((sprite_width(stats.button->btn())*0.5)-30);
+    if (this->m_optionsButtonNode->button->color() == "opts_home")
+        y_pos = home.button->y() + ((sprite_width(home.button->btn()) * 0.5) - 30);
+    else if (this->m_optionsButtonNode->button->color() == "opts_sound")
+        y_pos = sound.button->y() + ((sprite_width(sound.button->btn()) * 0.5) - 30);
+    else if (this->m_optionsButtonNode->button->color() == "opts_display")
+        y_pos = display.button->y() + ((sprite_width(display.button->btn()) * 0.5) - 30);
+    else if (this->m_optionsButtonNode->button->color() == "opts_stats")
+        y_pos = stats.button->y() + ((sprite_width(stats.button->btn()) * 0.5) - 30);
 
-    draw_text(this->m_optionsButtonNode->button->color().substr(5), 
-                COLOR_BLACK,  // colour 
-                "font_title", // font
-                60,           // size
-                x_pos,        // x position
-                y_pos         // y position
-            );
+    draw_text(this->m_optionsButtonNode->button->color().substr(5),
+              COLOR_BLACK,  // colour
+              "font_title", // font
+              60,           // size
+              x_pos,        // x position
+              y_pos         // y position
+    );
 
     // Check input in selector class.
     this->m_action = this->m_selectorOptionsMenu.checkForSelection(this->m_optionsButtonNode);
@@ -91,9 +97,11 @@ void Option::drawOptionsMenu()
 
 bool Option::checkAction()
 {
-    if (this->m_action == "home") return true;
+    if (this->m_action == "home")
+        return true;
 
-    if (this->m_action == "sound") soundMenu();
+    if (this->m_action == "sound")
+        soundMenu();
 
     return false;
 }
@@ -102,31 +110,30 @@ void Option::soundMenu()
 {
     write_line("into sound options mini menu");
 
-    //draw_text("Volume", COLOR_BLACK, "font_title", 60, 300, 200);
+    // draw_text("Volume", COLOR_BLACK, "font_title", 60, 300, 200);
 }
 
 float Option::getVolume()
-{ 
+{
     return m_volume / 100;
 }
 
 void Option::volumeControl()
 {
-    if(_selector == 2 && m_isSelected && key_typed(RIGHT_KEY) && m_volume < 100 && m_insideSeletor == 1)
+    if (_selector == 2 && m_isSelected && key_typed(RIGHT_KEY) && m_volume < 100 && m_insideSeletor == 1)
         m_volume += 20;
 
-    if(_selector == 2 && m_isSelected && key_typed(LEFT_KEY) && m_volume > 0 && m_insideSeletor == 1)
+    if (_selector == 2 && m_isSelected && key_typed(LEFT_KEY) && m_volume > 0 && m_insideSeletor == 1)
         m_volume -= 20;
 }
 
 void Option::setCurrentMusic()
 {
-    if(_selector == 2 && m_isSelected && m_volume < 100 && m_insideSeletor == 2)
-    {
-        if(key_typed(LEFT_KEY) && m_currentMusic > 1)
-            m_currentMusic = m_currentMusic-1;
-        if(key_typed(RIGHT_KEY) && m_currentMusic < 3)
-            m_currentMusic = m_currentMusic+1;
+    if (_selector == 2 && m_isSelected && m_volume < 100 && m_insideSeletor == 2) {
+        if (key_typed(LEFT_KEY) && m_currentMusic > 1)
+            m_currentMusic = m_currentMusic - 1;
+        if (key_typed(RIGHT_KEY) && m_currentMusic < 3)
+            m_currentMusic = m_currentMusic + 1;
     }
 }
 
@@ -137,10 +144,8 @@ int Option::getCurrentMusic()
 
 void Option::changeDisplay()
 {
-    if(_selector == 3 && m_isSelected)
-    {
-        switch (m_displayStyle)
-        {
+    if (_selector == 3 && m_isSelected) {
+        switch (m_displayStyle) {
         case 1:
             if (key_typed(RIGHT_KEY))
                 m_displayStyle = 2;
@@ -150,7 +155,7 @@ void Option::changeDisplay()
         case 2:
             if (key_typed(DOWN_KEY))
                 m_displayStyle = 4;
-            else if(key_typed(LEFT_KEY))
+            else if (key_typed(LEFT_KEY))
                 m_displayStyle = 1;
             break;
         case 3:
@@ -165,72 +170,56 @@ void Option::changeDisplay()
 
 bool Option::isChangeMusic()
 {
-    if (_selector == 2 && m_isSelected &&
-        m_volume < 100 && m_insideSeletor == 2 &&
-        (key_typed(LEFT_KEY) || key_typed(RIGHT_KEY)))
-    {
+    if (_selector == 2 && m_isSelected && m_volume < 100 && m_insideSeletor == 2 &&
+        (key_typed(LEFT_KEY) || key_typed(RIGHT_KEY))) {
         return true;
-    }
-    else return false;
+    } else
+        return false;
 }
 
 bool Option::isChangeVoLume()
 {
-    if (_selector == 2 && m_isSelected &&
-        m_volume < 100 && m_insideSeletor == 1 &&
-        (key_typed(LEFT_KEY) || key_typed(RIGHT_KEY)))
-    {
+    if (_selector == 2 && m_isSelected && m_volume < 100 && m_insideSeletor == 1 &&
+        (key_typed(LEFT_KEY) || key_typed(RIGHT_KEY))) {
         return true;
-    }
-    else return false;
+    } else
+        return false;
 }
 
 void Option::changeSelector()
 {
-    if (key_typed(P_KEY))
-    {
-        if (m_isSelected == false)
-        {
+    if (key_typed(P_KEY)) {
+        if (m_isSelected == false) {
             m_isSelected = true;
-        }
-        else if (m_isSelected == true)
-        {
+        } else if (m_isSelected == true) {
             m_isSelected = false;
         }
-        
-    }                    
-
-    if (key_typed(DOWN_KEY) &&_selector < 4 && !m_isSelected)
-    {
-        _selector=_selector+1;
     }
 
-    if (key_typed(UP_KEY) &&_selector > 1 && !m_isSelected)
-    {
-        _selector=_selector-1;
+    if (key_typed(DOWN_KEY) && _selector < 4 && !m_isSelected) {
+        _selector = _selector + 1;
     }
 
-    if (_selector==2 && m_isSelected == true && m_insideSeletor == 1)
-    {
-        if (key_typed(DOWN_KEY))
-        {
+    if (key_typed(UP_KEY) && _selector > 1 && !m_isSelected) {
+        _selector = _selector - 1;
+    }
+
+    if (_selector == 2 && m_isSelected == true && m_insideSeletor == 1) {
+        if (key_typed(DOWN_KEY)) {
             m_insideSeletor = 2;
         }
     }
 
-    if (_selector == 2 && m_isSelected == true && m_insideSeletor == 2)
-    {
-        if (key_typed(UP_KEY))
-        {
-            m_insideSeletor=1;
+    if (_selector == 2 && m_isSelected == true && m_insideSeletor == 2) {
+        if (key_typed(UP_KEY)) {
+            m_insideSeletor = 1;
         }
-    }             
+    }
 }
 
 void Option::updateOption()
 {
-    if (m_isOptionOpen)
-    {
+    if (m_isOptionOpen) {
         changeSelector();
         changeDisplay();
         setCurrentMusic();
@@ -241,9 +230,8 @@ void Option::updateOption()
     // if(!_isOptionOpen&&key_typed(O_KEY)){_isOptionOpen=true;}
     // if(_isOptionOpen&&key_typed(O_KEY)){_isOptionOpen=false;}
 
-    if (key_typed(O_KEY))
-    {
-        m_isOptionOpen=!m_isOptionOpen;
+    if (key_typed(O_KEY)) {
+        m_isOptionOpen = !m_isOptionOpen;
     }
 }
 
@@ -252,8 +240,7 @@ void Option::drawIntinialHub()
 
     draw_bitmap("back_ground", bitmap_width("backCurrentGame"), 0);
 
-    if (_selector == 1)
-    {
+    if (_selector == 1) {
         draw_bitmap("backCurrentGame", 0, 0);
         draw_bitmap("sound_notSelected", 0, bitmap_height("backCurrentGame"));
         // draw_bitmap();
@@ -263,37 +250,34 @@ void Option::drawIntinialHub()
         draw_text("no", color_red(), 700, 300);
     }
 
-    if (_selector == 2)
-    {
+    if (_selector == 2) {
         draw_bitmap("changeSound", 0, bitmap_height("backCurrentGame"));
         draw_bitmap("backGame_notSelected", 0, 0);
         // draw_bitmap();
         draw_bitmap("backMenu_notSelected", 0, 3 * bitmap_height("backCurrentGame"));
-        
-        fill_rectangle(color_red(),bitmap_width("backCurrentGame") + 200, 200, screen_width() - bitmap_width("backCurrentGame") - 400, 50);
+
+        fill_rectangle(color_red(), bitmap_width("backCurrentGame") + 200, 200,
+                       screen_width() - bitmap_width("backCurrentGame") - 400, 50);
         int a = screen_width() - bitmap_width("backCurrentGame") - 400;
         int b = a / 100 * m_volume;
         fill_rectangle(color_yellow(), bitmap_width("backCurrentGame") + 200, 200, b, 50);
         draw_text(std::to_string(screen_width() - bitmap_width("backCurrentGame")), color_red(), 300, 300);
 
-        if (m_insideSeletor == 1)
-        {
+        if (m_insideSeletor == 1) {
             draw_text("CHANGE SOUND", color_white(), bitmap_width("backCurrentGame") + 100, 200);
         }
 
-        if(m_insideSeletor == 2)
-        {
+        if (m_insideSeletor == 2) {
             draw_text("CHANGE MUSIC", color_white(), bitmap_width("backCurrentGame") + 100, 500);
             draw_text(std::to_string(m_currentMusic), color_white(), bitmap_width("backCurrentGame") + 250, 500);
         }
     }
 
-    if(_selector == 3)
-    {
+    if (_selector == 3) {
         double x = screen_width();
         double y = screen_height();
         double a = bitmap_width("backCurrentGame");
-        double rec_width = (x - a- 450) / 2;
+        double rec_width = (x - a - 450) / 2;
         double rec_height = (y - 450) / 2;
         double first_column_x = 150 + a;
         double second_column_x = a + 300 + rec_width;
@@ -303,14 +287,21 @@ void Option::drawIntinialHub()
         fill_rectangle(color_white(), second_column_x, first_row_y, rec_width, rec_height);
         fill_rectangle(color_white(), first_column_x, second_row_y, rec_width, rec_height);
         fill_rectangle(color_white(), second_column_x, second_row_y, rec_width, rec_height);
-        if (m_displayStyle == 1) { fill_rectangle(color_red(), first_column_x, first_row_y, rec_width, rec_height); }
-        if (m_displayStyle == 2) { fill_rectangle(color_red(), second_column_x, first_row_y, rec_width, rec_height); }
-        if (m_displayStyle == 3) { fill_rectangle(color_red(), first_column_x, second_row_y, rec_width, rec_height); }
-        if (m_displayStyle == 4) { fill_rectangle(color_red(), second_column_x, second_row_y, rec_width, rec_height); }
+        if (m_displayStyle == 1) {
+            fill_rectangle(color_red(), first_column_x, first_row_y, rec_width, rec_height);
+        }
+        if (m_displayStyle == 2) {
+            fill_rectangle(color_red(), second_column_x, first_row_y, rec_width, rec_height);
+        }
+        if (m_displayStyle == 3) {
+            fill_rectangle(color_red(), first_column_x, second_row_y, rec_width, rec_height);
+        }
+        if (m_displayStyle == 4) {
+            fill_rectangle(color_red(), second_column_x, second_row_y, rec_width, rec_height);
+        }
     }
 
-    if(_selector == 4)
-    {
+    if (_selector == 4) {
         draw_bitmap("backMenu", 0, 3 * bitmap_height("backCurrentGame"));
         draw_bitmap("sound_notSelected", 0, bitmap_height("backCurrentGame"));
         // draw_bitmap();

--- a/src/OptionsScreenButton.cpp
+++ b/src/OptionsScreenButton.cpp
@@ -1,40 +1,34 @@
 #include "OptionsScreenButton.h"
 
 // First constructor
-OptionsScreenButton::OptionsScreenButton(Color c, float scale)
-     : Button(c, scale)
+OptionsScreenButton::OptionsScreenButton(Color c, float scale) : Button(c, scale)
 {
-
 }
 
 /**
-* @brief returns the action 
-* 
-* @param keyinput 
-* @return string 
-*/
+ * @brief returns the action
+ *
+ * @param keyinput
+ * @return string
+ */
 std::string OptionsScreenButton::action(std::string keyinput)
 {
-    if (this->color() == btn_color(Button::HOME))
-    {
+    if (this->color() == btn_color(Button::HOME)) {
         // go to this screen
         write_line("Home");
         return "home";
     }
-    if (this->color() == btn_color(Button::SOUND))
-    {
+    if (this->color() == btn_color(Button::SOUND)) {
         // go to this screen
         write_line("Sound");
         return "sound";
     }
-    if (this->color() == btn_color(Button::DISPLAY))
-    {
+    if (this->color() == btn_color(Button::DISPLAY)) {
         // go to this screen
         write_line("Display");
         return "display";
     }
-    if (this->color() == btn_color(Button::STATS))
-    {
+    if (this->color() == btn_color(Button::STATS)) {
         // go to this screen
         write_line("Stats");
         return "stats";

--- a/src/Selector.cpp
+++ b/src/Selector.cpp
@@ -7,30 +7,26 @@ Selector::Selector(const std::string &cursor)
 }
 
 /**
-* @brief Checks key input, determining whether from game menu or splashscreen and updates that button.
-* 
-* @param buttonNode The current button that is selected.
-* @param gameMenu Checking if from game menu.
-* @return ButtonNode* 
-*/
-ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
+ * @brief Checks key input, determining whether from game menu or splashscreen and updates that button.
+ *
+ * @param buttonNode The current button that is selected.
+ * @param gameMenu Checking if from game menu.
+ * @return ButtonNode*
+ */
+ButtonNode *Selector::checkKeyInput(ButtonNode *buttonNode, bool isFromGameMenu)
 {
     this->m_isFromGameMenu = isFromGameMenu;
 
     // Highlight play button on start.
-    if (m_isFirstButton) 
+    if (m_isFirstButton)
         highlightFirst(buttonNode);
-    
+
     // If it is the game menu only allow left/right arrows selection.
-    if (isFromGameMenu)
-    {
+    if (isFromGameMenu) {
         // Check to ensure menu isn't currently sliding.
-        if (! m_isSlidingLeft && ! m_isSlidingRight)
-        {
-           // Slide left.
-            if ( (key_typed(LEFT_KEY) && !key_typed(RIGHT_KEY)) || 
-                 (key_typed(A_KEY) && !key_typed(D_KEY)) )
-            {
+        if (!m_isSlidingLeft && !m_isSlidingRight) {
+            // Slide left.
+            if ((key_typed(LEFT_KEY) && !key_typed(RIGHT_KEY)) || (key_typed(A_KEY) && !key_typed(D_KEY))) {
                 m_isSlidingLeft = true;
                 // Previous button becomes current button.
                 buttonNode = buttonNode->getPrev();
@@ -38,9 +34,7 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
                 highlightButton(buttonNode, "prev");
             }
             // Slide right.
-            if ( (key_typed(RIGHT_KEY) && !key_typed(LEFT_KEY)) || 
-                 (key_typed(D_KEY) && !key_typed(A_KEY)))
-            {
+            if ((key_typed(RIGHT_KEY) && !key_typed(LEFT_KEY)) || (key_typed(D_KEY) && !key_typed(A_KEY))) {
                 m_isSlidingRight = true;
                 // Next button becomes current button.
                 buttonNode = buttonNode->getNext();
@@ -48,12 +42,9 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
                 highlightButton(buttonNode, "next");
             }
         }
-    }
-    else 
-    {
-       // Move the selector up.
-        if (key_typed(UP_KEY) || key_typed(W_KEY))
-        {
+    } else {
+        // Move the selector up.
+        if (key_typed(UP_KEY) || key_typed(W_KEY)) {
             // Previous button becomes current button.
             buttonNode = buttonNode->getPrev();
             // Highlight the current button.
@@ -63,8 +54,7 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
                 sprite_set_y(this->m_cursorSprite, sprite_y(buttonNode->button->btn()));
         }
         // Move the selector down.
-        if (key_typed(DOWN_KEY) || key_typed(S_KEY))
-        {
+        if (key_typed(DOWN_KEY) || key_typed(S_KEY)) {
             // next button becomes current button.
             buttonNode = buttonNode->getNext();
             // Highlight the current button.
@@ -79,29 +69,26 @@ ButtonNode* Selector::checkKeyInput(ButtonNode* buttonNode, bool isFromGameMenu)
 }
 
 /**
-* @brief Checks for selection of a button.
-* 
-* @param buttonNode The current button that is selected.
-* @param gameMenu Check if selection is coming from game menu.
-* @return ** string 
-*/
-std::string Selector::checkForSelection(ButtonNode* buttonNode, bool isFromGameMenu)
+ * @brief Checks for selection of a button.
+ *
+ * @param buttonNode The current button that is selected.
+ * @param gameMenu Check if selection is coming from game menu.
+ * @return ** string
+ */
+std::string Selector::checkForSelection(ButtonNode *buttonNode, bool isFromGameMenu)
 {
     // If selection not from game menu.
-    if (!isFromGameMenu)
-    {
+    if (!isFromGameMenu) {
         // Return key returns the action of the selected button.
-        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY)) 
+        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY))
             return buttonNode->button->action();
-    }
-    else
-    {
-         // Return key returns the action of the selected button.
-        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY) ) 
+    } else {
+        // Return key returns the action of the selected button.
+        if (key_typed(RETURN_KEY) || key_typed(F_KEY) || key_typed(J_KEY))
             return buttonNode->button->action("return");
 
         // Escape key returns the action of the selected button.
-        if (key_typed(ESCAPE_KEY)) 
+        if (key_typed(ESCAPE_KEY))
             return buttonNode->button->action("escape");
     }
 
@@ -109,12 +96,12 @@ std::string Selector::checkForSelection(ButtonNode* buttonNode, bool isFromGameM
 }
 
 /**
-    * @brief Highlights the first button upon page load.
-    * 
-    * @param buttonNode The current selected button.
-    * @return void 
-    */
-void Selector::highlightFirst(ButtonNode* buttonNode)
+ * @brief Highlights the first button upon page load.
+ *
+ * @param buttonNode The current selected button.
+ * @return void
+ */
+void Selector::highlightFirst(ButtonNode *buttonNode)
 {
     // Get the current buttons sprite.
     sprite currentSprite = buttonNode->button->m_btn;
@@ -122,8 +109,7 @@ void Selector::highlightFirst(ButtonNode* buttonNode)
     sprite_toggle_layer_visible(currentSprite, 1);
 
     // Set start location of cursor.
-    if (! m_isFromGameMenu)
-    {
+    if (!m_isFromGameMenu) {
         if (this->m_renderCursor) {
             sprite_set_x(this->m_cursorSprite, sprite_x(buttonNode->button->btn()) - 200);
             sprite_set_y(this->m_cursorSprite, sprite_y(buttonNode->button->btn()));
@@ -134,13 +120,13 @@ void Selector::highlightFirst(ButtonNode* buttonNode)
 }
 
 /**
-* @brief Highlights the current selected button.
-* 
-* @param buttonNode The current button.
-* @param direction The direction the selector is moving.
-* @return ** void 
-*/
-void Selector::highlightButton(ButtonNode* buttonNode, std::string direction)
+ * @brief Highlights the current selected button.
+ *
+ * @param buttonNode The current button.
+ * @param direction The direction the selector is moving.
+ * @return ** void
+ */
+void Selector::highlightButton(ButtonNode *buttonNode, std::string direction)
 {
     // Sprite to store the previous sprite.
     sprite prevSprite = nullptr;

--- a/src/Splashscreen.cpp
+++ b/src/Splashscreen.cpp
@@ -1,6 +1,6 @@
 #include "Splashscreen.h"
 
 void Splashscreen::drawTitlePage()
-{ 
-    draw_bitmap(this->m_bmp, 0, 0); 
+{
+    draw_bitmap(this->m_bmp, 0, 0);
 }

--- a/src/Tip.cpp
+++ b/src/Tip.cpp
@@ -1,13 +1,12 @@
 #include "Tip.h"
 
 /**
-* @brief calculate the positioning of the container
-* 
-*/
+ * @brief calculate the positioning of the container
+ *
+ */
 void Tip::calculatePosition()
 {
-    switch (m_loc)
-    {
+    switch (m_loc) {
     case TOPLEFT:
         m_xOffset = WBORDER_OFFSET;
         m_yOffset = WBORDER_OFFSET;
@@ -45,33 +44,33 @@ Tip::Tip(string text, bitmap image, int duration, int charsPerLine, location loc
     this->m_loc = loc;
     this->m_duration = duration;
 
-    //Initialise bitmap
+    // Initialise bitmap
     m_bmpWidth = bitmap_width(image);
     m_bmpHeight = bitmap_height(image);
-    //Calculate number of lines
+    // Calculate number of lines
     m_numLines = m_textLength / charsPerLine;
-    //Calculate container height based off lines of text
+    // Calculate container height based off lines of text
     m_containerHeight = m_numLines * FONT_SIZE + FONT_SIZE + 2 * CONTENT_BUFFER;
-    //If the bitmap is bigger than the container, resize
+    // If the bitmap is bigger than the container, resize
     if (m_containerHeight < m_bmpHeight)
-        m_containerHeight = 2*CONTENT_BUFFER + m_bmpHeight;
-    //Calculate container width based on number of characters per line and bitmap width
+        m_containerHeight = 2 * CONTENT_BUFFER + m_bmpHeight;
+    // Calculate container width based on number of characters per line and bitmap width
     m_containerWidth = charsPerLine * 9 + 3 * CONTENT_BUFFER + m_bmpWidth;
 
     calculatePosition();
 };
 
 /**
-* @brief Construct a new Tip object
-* 
-* @param text the text to be displayed 
-* @param image the image to be displayed
-* @param anim the animation to be displayed
-* @param opt the drawing options for the bitmap
-* @param duration the duration of the tip
-* @param charsPerLine the number of characters per line
-* @param loc the location of the container
-*/
+ * @brief Construct a new Tip object
+ *
+ * @param text the text to be displayed
+ * @param image the image to be displayed
+ * @param anim the animation to be displayed
+ * @param opt the drawing options for the bitmap
+ * @param duration the duration of the tip
+ * @param charsPerLine the number of characters per line
+ * @param loc the location of the container
+ */
 Tip::Tip(string text, bitmap image, animation anim, drawing_options opt, int duration, int charsPerLine, location loc)
 {
     this->m_text = text;
@@ -81,19 +80,19 @@ Tip::Tip(string text, bitmap image, animation anim, drawing_options opt, int dur
     this->m_anim = anim;
     this->m_opt = opt;
     this->m_loc = loc;
-    this-> m_duration = duration;
+    this->m_duration = duration;
 
-    //Initialise bitmap
+    // Initialise bitmap
     m_bmpWidth = bitmap_cell_width(image);
     m_bmpHeight = bitmap_cell_height(image);
-    //Calculate number of lines
+    // Calculate number of lines
     m_numLines = m_textLength / charsPerLine;
-    //Calculate container height based off lines of text
+    // Calculate container height based off lines of text
     m_containerHeight = m_numLines * FONT_SIZE + FONT_SIZE + 2 * CONTENT_BUFFER;
-    //If the bitmap is bigger than the container, resize
+    // If the bitmap is bigger than the container, resize
     if (m_containerHeight < m_bmpHeight)
-        m_containerHeight = 2*CONTENT_BUFFER + m_bmpHeight;
-    //Calculate container width based on number of characters per line and bitmap width
+        m_containerHeight = 2 * CONTENT_BUFFER + m_bmpHeight;
+    // Calculate container width based on number of characters per line and bitmap width
     m_containerWidth = charsPerLine * 9 + 3 * CONTENT_BUFFER + m_bmpWidth;
 
     calculatePosition();
@@ -105,34 +104,37 @@ Tip::~Tip()
 }
 
 /**
-* @brief draw the tip
-* 
-*/
+ * @brief draw the tip
+ *
+ */
 void Tip::draw()
 {
-    //Initialise startTime upon first draw
+    // Initialise startTime upon first draw
     if (m_startTime.time_since_epoch().count() == 0)
         m_startTime = std::chrono::steady_clock::now();
 
-    //The tip has been visible for more than the specified duration, stop drawing
-    if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime).count() > 3000)
+    // The tip has been visible for more than the specified duration, stop drawing
+    if (std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_startTime).count() >
+        3000)
         return;
 
-    //Draw border rectangle
-    //NOTE: Variable i is used to scale the rectangle, each function call, animating the border.
-    fill_rectangle(rgba_color(0.0, 67.5, 75.7, 0.30), m_xOffset - BORDER_WIDTH, m_yOffset - BORDER_WIDTH, (m_containerWidth + (BORDER_WIDTH * 2)) / (m_i / 2), m_containerHeight + (BORDER_WIDTH * 2));
+    // Draw border rectangle
+    // NOTE: Variable i is used to scale the rectangle, each function call, animating the border.
+    fill_rectangle(rgba_color(0.0, 67.5, 75.7, 0.30), m_xOffset - BORDER_WIDTH, m_yOffset - BORDER_WIDTH,
+                   (m_containerWidth + (BORDER_WIDTH * 2)) / (m_i / 2), m_containerHeight + (BORDER_WIDTH * 2));
     if (m_i != 2)
         m_i--;
 
-    //Draw container rectangle
+    // Draw container rectangle
     fill_rectangle(COLOR_BLACK, m_xOffset, m_yOffset, m_containerWidth, m_containerHeight);
-    //Draw icon
+    // Draw icon
     draw_bitmap(m_image, m_xOffset + CONTENT_BUFFER, m_yOffset - m_bmpWidth / 2 + m_containerHeight / 2, m_opt);
-    //Draw the text
+    // Draw the text
     for (int i = 0; i < m_numLines + 1; i++)
-        draw_text(m_text.substr(i * m_charsPerLine, m_charsPerLine), COLOR_WHITE, "font_text", FONT_SIZE, m_xOffset + CONTENT_BUFFER * 2 + (m_bmpWidth), (FONT_SIZE * i) + m_yOffset + CONTENT_BUFFER);
+        draw_text(m_text.substr(i * m_charsPerLine, m_charsPerLine), COLOR_WHITE, "font_text", FONT_SIZE,
+                  m_xOffset + CONTENT_BUFFER * 2 + (m_bmpWidth), (FONT_SIZE * i) + m_yOffset + CONTENT_BUFFER);
 
-    //Update the animation
+    // Update the animation
     if (m_anim)
         update_animation(m_anim);
 }

--- a/src/program.cpp
+++ b/src/program.cpp
@@ -13,26 +13,27 @@ int main()
     open_window("arcade-machine", ARCADE_MACHINE_RES_X, ARCADE_MACHINE_RES_Y);
     window_toggle_border("arcade-machine");
 
-    // Do you want to play the intros and fetch new games? 
+    // Do you want to play the intros and fetch new games?
     bool play_intro = true;
     bool load_games = true;
 
     // Play Thoth Tech intro
-    if (play_intro) 
-    {
+    if (play_intro) {
         Arcade.playThothTechIntro();
         Arcade.playArcadeTeamIntro();
     }
 
     // Play SplashKit intro
-    if (load_games) Arcade.playSplashKitIntro();
-    
+    if (load_games)
+        Arcade.playSplashKitIntro();
+
     // Prepare the main menu
     Arcade.prepareMainMenu();
     // Draw the main menu
     Arcade.mainMenu();
 
-    // ISSUE - we never get here because the program exits forcibly from ArcadeMachine, rather than exiting from main and returning 0.
+    // ISSUE - we never get here because the program exits forcibly from ArcadeMachine, rather than exiting from main
+    // and returning 0.
     std::cout << "we never reach this point to output?\n";
 
     free_resource_bundle("bundle");


### PR DESCRIPTION
This PR adds support for running `clang-format` across the code base to enforce the coding conventions developed earlier by @lachfoy.

Because `clang-format` will need to be manually installed on user systems, running the code formatter isn't required - it's just a way of tidying up code as developers deem necessary. Hopefully this is the best of both worlds - not introducing friction in environment setup for future new developers - but also giving a handy tool for anyone who wants to use it.

An entry in the `Makefile` has been added for running the formatter across the whole project - `make format`. Be warned - it will re-write files - so ensure you've committed or backed up files if you want to revert the styling.

And for proof of concept, I've run `make format` on the main branch. It does tidy the code base up nicely...