### PR TITLE
Fix/refactor naming convention

### DIFF
--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -25,7 +25,7 @@
 #define ARCADE_MACHINE_BINARY_EXT ""
 #else
 #define ARCADE_MACHINE_OS "linux"
-#define ARCADE_MACHINE_BINARY_EXT ""
+#define ARCADE_MACHINE_BINARY_EXT ".out"
 #endif
 
 #endif

--- a/src/Process.cpp
+++ b/src/Process.cpp
@@ -23,7 +23,7 @@ pid_t spawnProcess(std::string directory, std::string fileName) {
 	// executes.
 	chdir(directory.c_str());
 
-	std::string cmd = "./" + fileName;
+	std::string cmd = "./builds/" + fileName;
 	auto pipe = popen(cmd.c_str(), "r");
 	if (! pipe) {
 		std::cerr << "Error executing popen" << std::endl;


### PR DESCRIPTION
This PR fixes a bug identified by @Delcari where launching a Linux process produced by the new automated build system in the `arcade-games` repository failed.

The failure was because

1. The Linux builds have an extension of `.out` but arcade machine had a blank file extension (resolved by 18bc6b1ded77598a7e436971b001790ec705a122)
2. Builds from the automated build script exist in a `builds` subdirectory, and Arcade Machine erroneously tried to execute them from the root of the game directory (resolved by b64d6284524d47a1a1a476029e5e0c1053dbc59e).
