### PR TITLE
Add script which  exits game after period of inactivity

### DIFF
--- a/.scripts/IdleTimeout.py
+++ b/.scripts/IdleTimeout.py
@@ -12,25 +12,13 @@ lastInput = datetime.now()
 inputs = []
 
 def has_input(file): 
-    data = file.read(24)
-    if data != None: #Event file may be empty if no input has been registered for some time
-        return True
-    else:
-        return False
-
-def get_last_input(file):
-    try: #Just in case the file is reset in between calling has_input() and here
-        data = file.read()[:-24]#Read LAST input
-        time = struct.unpack('4IHHI', data) 
-        time = datetime.fromtimestamp(time[0])
-    except:
-        time = datetime.now()
-    return time
+    data = file.read()
+    return data is not None #Event file may be empty if no input has been registered for some time
 
 def get_inputs():
     dir = r'/dev/input/'
     for file in listdir(dir):
-        if not path.isdir(dir+file) and "event" in file:
+        if(not path.isdir(dir+file) and "event" in file):
             f = open(dir+file, "rb")
             set_blocking(f.fileno(), False)
             inputs.append(f)
@@ -39,10 +27,7 @@ get_inputs()#Find all input devices
 while True:
     for f in inputs:
         if(has_input(f)):
-            #print("\nInput detected: " + f.name)
-            temp = get_last_input(f)
-            if(temp > lastInput): #Get most recent input from all inputs
-                lastInput = temp
+            lastInput = datetime.now()
 
     if(datetime.now() - lastInput > timedelta(minutes=timeout)):
         lastInput += timedelta(days=1)#Add time to the delay counter to stop the program restarting endlessly
@@ -50,6 +35,6 @@ while True:
         call(['pkill', '-f', processName]) #kill old process
         sleep(1)
         Popen([processName])
-    #else:
-        #print("Idle time: " + str(datetime.now() - lastInput))
+    # else:
+    #     print("Idle time: " + str(datetime.now() - lastInput))
     sleep(pollTime)

--- a/.scripts/IdleTimeout.py
+++ b/.scripts/IdleTimeout.py
@@ -1,5 +1,4 @@
 #Note this script requires super user privilages if the the user is not in the "input" group
-import struct
 from time import sleep
 from datetime import datetime, timedelta
 from os import set_blocking, listdir, path

--- a/.scripts/IdleTimeout.py
+++ b/.scripts/IdleTimeout.py
@@ -1,0 +1,55 @@
+#Note this script requires super user privilages if the the user is not in the "input" group
+import struct
+from time import sleep
+from datetime import datetime, timedelta
+from os import set_blocking, listdir, path
+from subprocess import call, Popen
+
+pollTime = 10 #Seconds
+timeout = 10  #minutes
+processName = 'emulationstation'
+lastInput = datetime.now()
+inputs = []
+
+def has_input(file): 
+    data = file.read(24)
+    if data != None: #Event file may be empty if no input has been registered for some time
+        return True
+    else:
+        return False
+
+def get_last_input(file):
+    try: #Just in case the file is reset in between calling has_input() and here
+        data = file.read()[:-24]#Read LAST input
+        time = struct.unpack('4IHHI', data) 
+        time = datetime.fromtimestamp(time[0])
+    except:
+        time = datetime.now()
+    return time
+
+def get_inputs():
+    dir = r'/dev/input/'
+    for file in listdir(dir):
+        if not path.isdir(dir+file) and "event" in file:
+            f = open(dir+file, "rb")
+            set_blocking(f.fileno(), False)
+            inputs.append(f)
+
+get_inputs()#Find all input devices
+while True:
+    for f in inputs:
+        if(has_input(f)):
+            #print("\nInput detected: " + f.name)
+            temp = get_last_input(f)
+            if(temp > lastInput): #Get most recent input from all inputs
+                lastInput = temp
+
+    if(datetime.now() - lastInput > timedelta(minutes=timeout)):
+        lastInput += timedelta(days=1)#Add time to the delay counter to stop the program restarting endlessly
+        #print("Idle timeout reached")
+        call(['pkill', '-f', processName]) #kill old process
+        sleep(1)
+        Popen([processName])
+    #else:
+        #print("Idle time: " + str(datetime.now() - lastInput))
+    sleep(pollTime)


### PR DESCRIPTION
# Description
Added a script which will restart emulationstation after 10 minutes of inactivity. Works by reading the timestamp on /dev/input/eventX files and comparing them against the current time. If there has been no input events for a certain period of time the script automatically kills and restarts the emulationstation process (effectively existing the game and returning to the main menu). Once this happens further restarts are delayed for 24 hours, or until some input is registered (which resets the countdown timer back to the default value I.E. 10 minutes).

The script does a non-blocking read of the last 24 bytes of each eventX file. This should catch any input event regardless of the input method used to interact with the game I.E. real keyboard, emulated keyboard, mouse, controller.

The frequency at which the script polls for input events, the timeout and the application the script restarts are controlled by variables and can be tweaked. A 10 second poll time seems to provide  a good balance between accurately tracking inputs and not tying up system resources.

In order for the script to start when the arcade does the rc.local file must be modified to include a call to start the python script on startup. This can be done from the pie with the following commands:
`sudo nano /etc/rc.local`
Then in the  rc.local file on the line directly above `exit 0` add:
`sudo -u deakin python3  /home/deakin/IdleTimeout.py &` 

**Note:**
- Replace "deakin" with the username of the default arcade machine user. This is required due to emulationstation refusing to run as a super user.
- Make sure to add the ampersand at the end of the line, otherwise Linux will not fork the script and the system will appear to hang.

The script requires that the user be in the "input" group in order to read  /dev/input files.

## Type of change
Extension to existing  function.
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
This has been tested on both a "regular" desktop Linux distribution with arbitrary programs such as mousepad & firefox as well as on the raspberrypi itself with emulationstation. In both instances the  script will correctly monitor input and restart the program after the timeout is reached. Further restarts are then postponed until the user interacts with the host again.

## Testing Checklist
- [ ] Tested with sktest
- [ ] Tested with skunit_tests

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have requested a review from ... on the Pull Request
