### PR TITLE
Update to README for T3 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,4 +87,9 @@ If you prefer to compile without the Makefile, use the following command:
 
 ## Contributing
 
+Thank you to all the contributors!
+
+[<img src="https://github.com/{{ contributor }}.png" width="60px;"/><br /><sub><ahref="https://github.com/{{ contributor }}">{{ contributor }}</a></sub>](https://github.com/{{ contributor }}/{{ repository }}
+
 We welcome contributions to improve Arcade Machine and make it even better! If you’re interested in contributing, please review our guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) file. Contributions can include bug fixes, new features, documentation improvements, or general enhancements. We appreciate your support in making Arcade Machine a great experience for all users!
+

--- a/README.md
+++ b/README.md
@@ -1,25 +1,86 @@
-# arcade-machine
-An application to showcase and execute Splashkit games  
+# Arcade Machine
 
-## Pre-requisites (all operating systems)
+**Arcade Machine** is an interactive application built to showcase and execute games created with the [SplashKit SDK](https://github.com/thoth-tech/splashkit-core). Designed as a hub for all your SplashKit games, Arcade Machine provides an efficient and user-friendly way to compile, organize, and run games in one place. It’s ideal for both developers and players who want to easily access and test their creations.
 
-+ Install the [SplashKit](https://splashkit.io) SDK using the [guide](https://splashkit.io/articles/installation/)
+## Pre-requisites
 
-## Pre-requisites (mingw32 / Windows)
+### General (All Operating Systems)
 
-+ Install `make` using `pacman -S make`
+- Install the SplashKit SDK by following the [installation guide](http://www.splashkit.io/articles/installation/).
 
-## Building arcade machine (using the Makefile)
-Compiling Arcade Machine using the Makefile allows incremental building of changed objects.
+#### Windows (mingw32)
+
+- Install `make` by running the following command in your terminal:
+
+    ```bash
+    pacman -S make
+    ```
+
+#### macOS
+
+- Install `make` (if not already installed) by installing Xcode Command Line Tools:
+
+    ```bash
+    xcode-select --install
+    ```
+
+#### Linux (Debian/Ubuntu)
+
+- Install `make` by running the following command in your terminal:
+
+    ```bash
+    sudo apt install make
+    ```
+
+## Building Arcade Machine
+
+You can build Arcade Machine either using the provided Makefile or by compiling manually. Choose the method that best suits your workflow.
+
+### Building with Makefile
+
+Using the Makefile allows for incremental building, only re-compiling files that have changed. This is the recommended approach for efficient development.
+
+1. Navigate to the project directory:
+
+    ```bash
+    cd arcade-machine
+    ```
+
+2. Run the build command:
+
+    ```bash
+    make
+    ```
+
+3. Start Arcade Machine:
+
+    ```bash
+    ./ArcadeMachine
+    ```
+
+To rebuild after making code changes, simply use `make` again. For a clean build, use:
 
 ```bash
-cd arcade-machine
+make clean
 make
-./ArcadeMachine
 ```
 
-Subsequent builds (as you change code) can be completed by using just `make`. If you need to run a clean build again, you can use `make clean` first proceeded by `make`.
+### Building Manually
 
-## Building arcade machine (manually)
-+ Compile the application with the command ```skm clang++ src/* -Iinclude -lstdc++fs -o test```  
-+ Run the application ```./test```
+If you prefer to compile without the Makefile, use the following command:
+
+1. Compile the application:
+
+    ```bash
+    skm clang++ src/* -Iinclude -lstdc++fs -o test
+    ```
+
+2. Run the application:
+
+    ```bash
+    ./test
+    ```
+
+## Contributing
+
+We welcome contributions to improve Arcade Machine and make it even better! If you’re interested in contributing, please review our guidelines in the [CONTRIBUTING.md](./CONTRIBUTING.md) file. Contributions can include bug fixes, new features, documentation improvements, or general enhancements. We appreciate your support in making Arcade Machine a great experience for all users!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center" width="100%">
+<p align="center" width="40%">
     <img width="40%" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<p align="center" width="40%">
-    <img width="40%" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
+<p align="left">
+    <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
 # Arcade Machine

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center" width="100%">
+    <img width="40%" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
+</p>
+
 # Arcade Machine
 
 **Arcade Machine** is an interactive application built to showcase and execute games created with the [SplashKit SDK](https://github.com/thoth-tech/splashkit-core). Designed as a hub for all your SplashKit games, Arcade Machine provides an efficient and user-friendly way to compile, organize, and run games in one place. It’s ideal for both developers and players who want to easily access and test their creations.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ### General (All Operating Systems)
 
-- Install the SplashKit SDK by following the [installation guide](http://www.splashkit.io/articles/installation/).
+- Install the SplashKit SDK by following the [installation guide](https://splashkit.io/installation/).
 
 #### Windows (mingw32)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
+![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/arcade-machine?label=Contributors&color=F5A623)
+![GitHub issues](https://img.shields.io/github/issues/thoth-tech/arcade-machine?label=Issues&color=F5A623)
+![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/arcade-machine?label=Pull%20Requests&color=F5A623)
+![Forks](https://img.shields.io/github/forks/thoth-tech/arcade-machine?label=Forks&color=F5A623)
+![Stars](https://img.shields.io/github/stars/thoth-tech/arcade-machine?label=Stars&color=F5A623)
+
 # Arcade Machine
 
 **Arcade Machine** is an interactive application built to showcase and execute games created with the [SplashKit SDK](https://github.com/thoth-tech/splashkit-core). Designed as a hub for all your SplashKit games, Arcade Machine provides an efficient and user-friendly way to compile, organize, and run games in one place. It’s ideal for both developers and players who want to easily access and test their creations.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
 
-![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/arcade-machine?label=Contributors&color=F5A623)
-![GitHub issues](https://img.shields.io/github/issues/thoth-tech/arcade-machine?label=Issues&color=F5A623)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/arcade-machine?label=Pull%20Requests&color=F5A623)
-![Forks](https://img.shields.io/github/forks/thoth-tech/arcade-machine?label=Forks&color=F5A623)
-![Stars](https://img.shields.io/github/stars/thoth-tech/arcade-machine?label=Stars&color=F5A623)
+[![GitHub contributors](https://img.shields.io/github/contributors/thoth-tech/arcade-machine?label=Contributors&color=F5A623)](https://github.com/thoth-tech/arcade-machine/graphs/contributors)
+[![GitHub issues](https://img.shields.io/github/issues/thoth-tech/arcade-machine?label=Issues&color=F5A623)](https://github.com/thoth-tech/arcade-machine/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/arcade-machine?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/arcade-machine/pulls)
+[![Forks](https://img.shields.io/github/forks/thoth-tech/arcade-machine?label=Forks&color=F5A623)](https://github.com/thoth-tech/arcade-machine/network/members)
+[![Stars](https://img.shields.io/github/stars/thoth-tech/arcade-machine?label=Stars&color=F5A623)](https://github.com/thoth-tech/arcade-machine/stargazers)
+
 
 # Arcade Machine
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Arcade Machine
+
 <p align="left">
     <img width="150px" src="https://github.com/thoth-tech/.github/blob/main/images/splashkit.png"/>
 </p>
@@ -7,9 +9,6 @@
 [![GitHub pull requests](https://img.shields.io/github/issues-pr/thoth-tech/arcade-machine?label=Pull%20Requests&color=F5A623)](https://github.com/thoth-tech/arcade-machine/pulls)
 [![Forks](https://img.shields.io/github/forks/thoth-tech/arcade-machine?label=Forks&color=F5A623)](https://github.com/thoth-tech/arcade-machine/network/members)
 [![Stars](https://img.shields.io/github/stars/thoth-tech/arcade-machine?label=Stars&color=F5A623)](https://github.com/thoth-tech/arcade-machine/stargazers)
-
-
-# Arcade Machine
 
 **Arcade Machine** is an interactive application built to showcase and execute games created with the [SplashKit SDK](https://github.com/thoth-tech/splashkit-core). Designed as a hub for all your SplashKit games, Arcade Machine provides an efficient and user-friendly way to compile, organize, and run games in one place. It’s ideal for both developers and players who want to easily access and test their creations.
 


### PR DESCRIPTION
# Update README

### Description
This PR improves the Arcade Machine README by providing additional instructions for installing `make` on macOS and Linux, along with a clearer introduction and a new Contributing section. These changes make it easier for developers across different operating systems to set up and contribute to Arcade Machine.

### Key Updates

1. **Expanded Pre-requisites**: 
   - Added commands for installing `make` on macOS and Linux (Debian/Ubuntu) alongside existing Windows instructions.
   - Included instructions for macOS users to install `make` through Xcode Command Line Tools.
   
2. **Enhanced Introduction**: Refined the introduction to better explain Arcade Machine’s purpose and audience, emphasizing its role as a hub for SplashKit games.

3. **New Contributing Section**: Added a section encouraging contributions and providing a link to the `CONTRIBUTING.md` file for guidelines on how to get involved.

- **GitHub Stats**: Added badges for GitHub contributors, issues, pull requests, forks, and stars for both **SplashKit** and **Thoth Tech** repositories. These stats offer an at-a-glance view of project activity and community engagement.

### Motivation
The goal of these changes is to make the README more comprehensive and user-friendly, especially for new contributors and users in preparation for Trimester 3 2024.