### PR TITLE
Ensure that the machine can recognise that it runs on arm64 & enforcing -Ofast when compiling from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 
 ArcadeMachine: $(obj)
 	-.scripts/generate-stats.sh
-	$(CXX) -o $@ $^ $(LDFLAGS) $(OSFLAGS)
+	$(CXX) -o $@ $^ $(LDFLAGS) 
 
 clean:
 	rm $(obj)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 INCDIRS = -Iinclude
-CXX = skm g++ $(INCDIRS)
+CXX = skm g++ $(INCDIRS) -Ofast
 src = $(wildcard src/*.cpp)
 obj = $(src:.cpp=.o)
 
@@ -13,8 +13,6 @@ else
         LDFLAGS += -lstdc++fs
     endif
 endif
-
-OSFLAGS = -O3
 
 ArcadeMachine: $(obj)
 	-.scripts/generate-stats.sh

--- a/include/Configuration.h
+++ b/include/Configuration.h
@@ -11,7 +11,7 @@
 #define ARCADE_MACHINE_PATH_SEP "/"
 #endif
 
-#ifdef __arm__
+#if defined(__arm__) || defined(__aarch64__)
 #define ARCADE_MACHINE_INSTRUCTION_SET "arm"
 #else
 #define ARCADE_MACHINE_INSTRUCTION_SET "x86"


### PR DESCRIPTION
# Description

Resolves an issue of ArcadeMachine being unable to recognise itself on arm64 and hence requiring x86 binaries when running on arm64, also enforcing the `-Ofast` when compiling the machine.

## Type of change

_Please delete options that are not relevant._

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The machine has been run on RPi 5 (Debian 13). It was pulling the ARM versions of games rather than x86.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] ~~I have commented my code in hard-to-understand areas~~
- [x] ~~I have made corresponding changes to the documentation~~
- [x] My changes generate no new warnings